### PR TITLE
各カテゴリのスレッドテーブルのリレーション・その活用

### DIFF
--- a/app/Http/Controllers/Dashboard/ClubThreadController.php
+++ b/app/Http/Controllers/Dashboard/ClubThreadController.php
@@ -2,33 +2,11 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\Dashboard\NotLoggedIn\ClubThreadController as Controller;
 use App\Models\ClubThread;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class ClubThreadController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
     /**
      * Store a newly created resource in storage.
      *
@@ -48,79 +26,5 @@ class ClubThreadController extends Controller
             'message' => $message
         ]);
         return $message_id;
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param string $user_email
-     * @param string $thread_id
-     * @param int $pre_max_message_id
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
-    {
-        return ClubThread::with('user')
-            ->select(
-                'club_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'club_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'club_threads.message_id');
-            })
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
-            })
-            ->where('club_threads.hub_id', '=', $thread_id)
-            ->where('club_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('club_threads.message_id')
-            ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\ClubThread  $clubThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(ClubThread $clubThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\ClubThread  $clubThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, ClubThread $clubThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\ClubThread  $clubThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(ClubThread $clubThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/ClubThreadController.php
+++ b/app/Http/Controllers/Dashboard/ClubThreadController.php
@@ -9,12 +9,6 @@ use Illuminate\Support\Facades\DB;
 
 class ClubThreadController extends Controller
 {
-    /** @var string */
-    private $user_email;
-
-    /** @var string */
-    private $thread_id;
-
     /**
      * Display a listing of the resource.
      *
@@ -39,20 +33,18 @@ class ClubThreadController extends Controller
      * Store a newly created resource in storage.
      *
      * @param string $thread_id
-     * @param string $user_name
-     * @param string $user_email
+     * @param string $user_id
      * @param string $message
      *
      * @return int
      */
-    public function store(string $thread_id, string $user_name, string $user_email, string $message)
+    public function store(string $thread_id, string $user_id, string $message)
     {
-        $message_id = ClubThread::where('thread_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
+        $message_id = ClubThread::where('hub_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
         ClubThread::create([
-            'thread_id' => $thread_id,
+            'hub_id' => $thread_id,
+            'user_id' => $user_id,
             'message_id' => $message_id,
-            'user_name' => $user_name,
-            'user_email' => $user_email,
             'message' => $message
         ]);
         return $message_id;
@@ -69,32 +61,30 @@ class ClubThreadController extends Controller
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->user_email = $user_email;
-        $this->thread_id = $thread_id;
-
-        return ClubThread::select(
-            'club_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return ClubThread::with('user')
+            ->select(
+                'club_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'club_threads.message_id');
             })
-            ->leftjoin('likes AS likes2', function ($join) {
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
                 $join
-                    ->where('likes2.thread_id', '=', $this->thread_id)
-                    ->where('likes2.user_email', '=', $this->user_email)
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
                     ->whereColumn('likes2.message_id', '=', 'club_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
             })
-            ->where('club_threads.thread_id', '=', $this->thread_id)
+            ->where('club_threads.hub_id', '=', $thread_id)
             ->where('club_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('club_threads.message_id')
             ->get();

--- a/app/Http/Controllers/Dashboard/CollegeYearThreadController.php
+++ b/app/Http/Controllers/Dashboard/CollegeYearThreadController.php
@@ -9,12 +9,6 @@ use Illuminate\Support\Facades\DB;
 
 class CollegeYearThreadController extends Controller
 {
-    /** @var string */
-    private $user_email;
-
-    /** @var string */
-    private $thread_id;
-
     /**
      * Display a listing of the resource.
      *
@@ -39,20 +33,18 @@ class CollegeYearThreadController extends Controller
      * Store a newly created resource in storage.
      *
      * @param string $thread_id
-     * @param string $user_name
-     * @param string $user_email
+     * @param string $user_id
      * @param string $message
      *
      * @return int
      */
-    public function store(string $thread_id, string $user_name, string $user_email, string $message)
+    public function store(string $thread_id, string $user_id, string $message)
     {
-        $message_id = CollegeYearThread::where('thread_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
+        $message_id = CollegeYearThread::where('hub_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
         CollegeYearThread::create([
-            'thread_id' => $thread_id,
+            'hub_id' => $thread_id,
+            'user_id' => $user_id,
             'message_id' => $message_id,
-            'user_name' => $user_name,
-            'user_email' => $user_email,
             'message' => $message
         ]);
         return $message_id;
@@ -69,32 +61,30 @@ class CollegeYearThreadController extends Controller
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->user_email = $user_email;
-        $this->thread_id = $thread_id;
-
-        return CollegeYearThread::select(
-            'college_year_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return CollegeYearThread::with('user')
+            ->select(
+                'college_year_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'college_year_threads.message_id');
             })
-            ->leftjoin('likes AS likes2', function ($join) {
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
                 $join
-                    ->where('likes2.thread_id', '=', $this->thread_id)
-                    ->where('likes2.user_email', '=', $this->user_email)
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
                     ->whereColumn('likes2.message_id', '=', 'college_year_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
             })
-            ->where('college_year_threads.thread_id', '=', $this->thread_id)
+            ->where('college_year_threads.hub_id', '=', $thread_id)
             ->where('college_year_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('college_year_threads.message_id')
             ->get();

--- a/app/Http/Controllers/Dashboard/CollegeYearThreadController.php
+++ b/app/Http/Controllers/Dashboard/CollegeYearThreadController.php
@@ -2,33 +2,11 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\Dashboard\NotLoggedIn\CollegeYearThreadController as Controller;
 use App\Models\CollegeYearThread;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class CollegeYearThreadController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
     /**
      * Store a newly created resource in storage.
      *
@@ -48,79 +26,5 @@ class CollegeYearThreadController extends Controller
             'message' => $message
         ]);
         return $message_id;
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param string $user_email
-     * @param string $thread_id
-     * @param int $pre_max_message_id
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
-    {
-        return CollegeYearThread::with('user')
-            ->select(
-                'college_year_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'college_year_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'college_year_threads.message_id');
-            })
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
-            })
-            ->where('college_year_threads.hub_id', '=', $thread_id)
-            ->where('college_year_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('college_year_threads.message_id')
-            ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\CollegeYearThread  $collegeYearThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(CollegeYearThread $collegeYearThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\CollegeYearThread  $collegeYearThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, CollegeYearThread $collegeYearThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\CollegeYearThread  $collegeYearThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(CollegeYearThread $collegeYearThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/DepartmentThreadController.php
+++ b/app/Http/Controllers/Dashboard/DepartmentThreadController.php
@@ -2,33 +2,11 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\Dashboard\NotLoggedIn\DepartmentThreadController as Controller;
 use App\Models\DepartmentThread;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class DepartmentThreadController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
     /**
      * Store a newly created resource in storage.
      *
@@ -48,79 +26,5 @@ class DepartmentThreadController extends Controller
             'message' => $message
         ]);
         return $message_id;
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param string $user_email
-     * @param string $thread_id
-     * @param int $pre_max_message_id
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
-    {
-        return DepartmentThread::with('user')
-            ->select(
-                'department_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'department_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'department_threads.message_id');
-            })
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
-            })
-            ->where('department_threads.hub_id', '=', $thread_id)
-            ->where('department_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('department_threads.message_id')
-            ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\DepartmentThread  $departmentThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(DepartmentThread $departmentThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\DepartmentThread  $departmentThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, DepartmentThread $departmentThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\DepartmentThread  $departmentThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(DepartmentThread $departmentThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/DepartmentThreadController.php
+++ b/app/Http/Controllers/Dashboard/DepartmentThreadController.php
@@ -9,12 +9,6 @@ use Illuminate\Support\Facades\DB;
 
 class DepartmentThreadController extends Controller
 {
-    /** @var string */
-    private $user_email;
-
-    /** @var string */
-    private $thread_id;
-
     /**
      * Display a listing of the resource.
      *
@@ -39,20 +33,18 @@ class DepartmentThreadController extends Controller
      * Store a newly created resource in storage.
      *
      * @param string $thread_id
-     * @param string $user_name
-     * @param string $user_email
+     * @param string $user_id
      * @param string $message
      *
      * @return int
      */
-    public function store(string $thread_id, string $user_name, string $user_email, string $message)
+    public function store(string $thread_id, string $user_id, string $message)
     {
-        $message_id = DepartmentThread::where('thread_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
+        $message_id = DepartmentThread::where('hub_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
         DepartmentThread::create([
-            'thread_id' => $thread_id,
+            'hub_id' => $thread_id,
+            'user_id' => $user_id,
             'message_id' => $message_id,
-            'user_name' => $user_name,
-            'user_email' => $user_email,
             'message' => $message
         ]);
         return $message_id;
@@ -69,32 +61,30 @@ class DepartmentThreadController extends Controller
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->user_email = $user_email;
-        $this->thread_id = $thread_id;
-
-        return DepartmentThread::select(
-            'department_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return DepartmentThread::with('user')
+            ->select(
+                'department_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'department_threads.message_id');
             })
-            ->leftjoin('likes AS likes2', function ($join) {
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
                 $join
-                    ->where('likes2.thread_id', '=', $this->thread_id)
-                    ->where('likes2.user_email', '=', $this->user_email)
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
                     ->whereColumn('likes2.message_id', '=', 'department_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
             })
-            ->where('department_threads.thread_id', '=', $this->thread_id)
+            ->where('department_threads.hub_id', '=', $thread_id)
             ->where('department_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('department_threads.message_id')
             ->get();

--- a/app/Http/Controllers/Dashboard/JobHuntingThreadController.php
+++ b/app/Http/Controllers/Dashboard/JobHuntingThreadController.php
@@ -2,33 +2,11 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\Dashboard\NotLoggedIn\JobHuntingThreadController as Controller;
 use App\Models\JobHuntingThread;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class JobHuntingThreadController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
     /**
      * Store a newly created resource in storage.
      *
@@ -48,79 +26,5 @@ class JobHuntingThreadController extends Controller
             'message' => $message
         ]);
         return $message_id;
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param string $user_email
-     * @param string $thread_id
-     * @param int $pre_max_message_id
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
-    {
-        return JobHuntingThread::with('user')
-            ->select(
-                'job_hunting_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'job_hunting_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'job_hunting_threads.message_id');
-            })
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
-            })
-            ->where('job_hunting_threads.hub_id', '=', $thread_id)
-            ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('job_hunting_threads.message_id')
-            ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\JobHuntingThread  $jobHuntingThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(JobHuntingThread $jobHuntingThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\JobHuntingThread  $jobHuntingThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, JobHuntingThread $jobHuntingThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\JobHuntingThread  $jobHuntingThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(JobHuntingThread $jobHuntingThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/JobHuntingThreadController.php
+++ b/app/Http/Controllers/Dashboard/JobHuntingThreadController.php
@@ -9,12 +9,6 @@ use Illuminate\Support\Facades\DB;
 
 class JobHuntingThreadController extends Controller
 {
-    /** @var string */
-    private $user_email;
-
-    /** @var string */
-    private $thread_id;
-
     /**
      * Display a listing of the resource.
      *
@@ -39,20 +33,18 @@ class JobHuntingThreadController extends Controller
      * Store a newly created resource in storage.
      *
      * @param string $thread_id
-     * @param string $user_name
-     * @param string $user_email
+     * @param string $user_id
      * @param string $message
      *
      * @return int
      */
-    public function store(string $thread_id, string $user_name, string $user_email, string $message)
+    public function store(string $thread_id, string $user_id, string $message)
     {
-        $message_id = JobHuntingThread::where('thread_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
+        $message_id = JobHuntingThread::where('hub_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
         JobHuntingThread::create([
-            'thread_id' => $thread_id,
+            'hub_id' => $thread_id,
+            'user_id' => $user_id,
             'message_id' => $message_id,
-            'user_name' => $user_name,
-            'user_email' => $user_email,
             'message' => $message
         ]);
         return $message_id;
@@ -69,32 +61,30 @@ class JobHuntingThreadController extends Controller
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->user_email = $user_email;
-        $this->thread_id = $thread_id;
-
-        return JobHuntingThread::select(
-            'job_hunting_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return JobHuntingThread::with('user')
+            ->select(
+                'job_hunting_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'job_hunting_threads.message_id');
             })
-            ->leftjoin('likes AS likes2', function ($join) {
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
                 $join
-                    ->where('likes2.thread_id', '=', $this->thread_id)
-                    ->where('likes2.user_email', '=', $this->user_email)
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
                     ->whereColumn('likes2.message_id', '=', 'job_hunting_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
             })
-            ->where('job_hunting_threads.thread_id', '=', $this->thread_id)
+            ->where('job_hunting_threads.hub_id', '=', $thread_id)
             ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('job_hunting_threads.message_id')
             ->get();

--- a/app/Http/Controllers/Dashboard/LectureThreadController.php
+++ b/app/Http/Controllers/Dashboard/LectureThreadController.php
@@ -9,12 +9,6 @@ use Illuminate\Support\Facades\DB;
 
 class LectureThreadController extends Controller
 {
-    /** @var string */
-    private $user_email;
-
-    /** @var string */
-    private $thread_id;
-
     /**
      * Display a listing of the resource.
      *
@@ -39,20 +33,18 @@ class LectureThreadController extends Controller
      * Store a newly created resource in storage.
      *
      * @param string $thread_id
-     * @param string $user_name
-     * @param string $user_email
+     * @param string $user_id
      * @param string $message
      *
      * @return int
      */
-    public function store(string $thread_id, string $user_name, string $user_email, string $message)
+    public function store(string $thread_id, string $user_id, string $message)
     {
-        $message_id = LectureThread::where('thread_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
+        $message_id = LectureThread::where('hub_id', '=', $thread_id)->max('message_id') + 1 ?? 0;
         LectureThread::create([
-            'thread_id' => $thread_id,
+            'hub_id' => $thread_id,
+            'user_id' => $user_id,
             'message_id' => $message_id,
-            'user_name' => $user_name,
-            'user_email' => $user_email,
             'message' => $message
         ]);
         return $message_id;
@@ -69,32 +61,30 @@ class LectureThreadController extends Controller
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->user_email = $user_email;
-        $this->thread_id = $thread_id;
-
-        return LectureThread::select(
-            'lecture_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return LectureThread::with('user')
+            ->select(
+                'lecture_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'lecture_threads.message_id');
             })
-            ->leftjoin('likes AS likes2', function ($join) {
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
                 $join
-                    ->where('likes2.thread_id', '=', $this->thread_id)
-                    ->where('likes2.user_email', '=', $this->user_email)
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
                     ->whereColumn('likes2.message_id', '=', 'lecture_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
             })
-            ->where('lecture_threads.thread_id', '=', $this->thread_id)
+            ->where('lecture_threads.hub_id', '=', $thread_id)
             ->where('lecture_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('lecture_threads.message_id')
             ->get();

--- a/app/Http/Controllers/Dashboard/LectureThreadController.php
+++ b/app/Http/Controllers/Dashboard/LectureThreadController.php
@@ -2,33 +2,11 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\Dashboard\NotLoggedIn\LectureThreadController as Controller;
 use App\Models\LectureThread;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class LectureThreadController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
     /**
      * Store a newly created resource in storage.
      *
@@ -48,79 +26,5 @@ class LectureThreadController extends Controller
             'message' => $message
         ]);
         return $message_id;
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param string $user_email
-     * @param string $thread_id
-     * @param int $pre_max_message_id
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
-    {
-        return LectureThread::with('user')
-            ->select(
-                'lecture_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'lecture_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'lecture_threads.message_id');
-            })
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
-            })
-            ->where('lecture_threads.hub_id', '=', $thread_id)
-            ->where('lecture_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('lecture_threads.message_id')
-            ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\LectureThread  $lectureThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(LectureThread $lectureThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\LectureThread  $lectureThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, LectureThread $lectureThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\LectureThread  $lectureThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(LectureThread $lectureThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
@@ -4,107 +4,47 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\ClubThread;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class ClubThreadController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
      * Display the specified resource.
      *
+     * @param string $user_email
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $thread_id, int $pre_max_message_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->thread_id = $thread_id;
-
-        return ClubThread::select(
-            'club_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('0 AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return ClubThread::with('user')
+            ->select(
+                'club_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'club_threads.message_id');
+            })
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
+                $join
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
+                    ->whereColumn('likes2.message_id', '=', 'club_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
             })
-            ->where('club_threads.thread_id', '=', $this->thread_id)
+            ->where('club_threads.hub_id', '=', $thread_id)
             ->where('club_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('club_threads.message_id')
             ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\ClubThread  $clubThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(ClubThread $clubThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\ClubThread  $clubThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, ClubThread $clubThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\ClubThread  $clubThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(ClubThread $clubThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
@@ -4,107 +4,47 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\CollegeYearThread;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class CollegeYearThreadController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
      * Display the specified resource.
      *
+     * @param string $user_email
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $thread_id, int $pre_max_message_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->thread_id = $thread_id;
-
-        return CollegeYearThread::select(
-            'college_year_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('0 AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return CollegeYearThread::with('user')
+            ->select(
+                'college_year_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'college_year_threads.message_id');
+            })
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
+                $join
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
+                    ->whereColumn('likes2.message_id', '=', 'college_year_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
             })
-            ->where('college_year_threads.thread_id', '=', $this->thread_id)
+            ->where('college_year_threads.hub_id', '=', $thread_id)
             ->where('college_year_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('college_year_threads.message_id')
             ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\CollegeYearThread  $collegeYearThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(CollegeYearThread $collegeYearThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\CollegeYearThread  $collegeYearThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, CollegeYearThread $collegeYearThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\CollegeYearThread  $collegeYearThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(CollegeYearThread $collegeYearThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
@@ -4,110 +4,47 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\DepartmentThread;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class DepartmentThreadController extends Controller
 {
-    /** @var string */
-    private $thread_id;
-
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
     /**
      * Display the specified resource.
      *
+     * @param string $user_email
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $thread_id, int $pre_max_message_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->thread_id = $thread_id;
-
-        return DepartmentThread::select(
-            'department_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('0 AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return DepartmentThread::with('user')
+            ->select(
+                'department_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'department_threads.message_id');
+            })
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
+                $join
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
+                    ->whereColumn('likes2.message_id', '=', 'department_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
             })
-            ->where('department_threads.thread_id', '=', $this->thread_id)
+            ->where('department_threads.hub_id', '=', $thread_id)
             ->where('department_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('department_threads.message_id')
             ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\DepartmentThread  $departmentThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(DepartmentThread $departmentThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\DepartmentThread  $departmentThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, DepartmentThread $departmentThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\DepartmentThread  $departmentThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(DepartmentThread $departmentThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
@@ -4,107 +4,47 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\JobHuntingThread;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class JobHuntingThreadController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
      * Display the specified resource.
      *
+     * @param string $user_email
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $thread_id, int $pre_max_message_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->thread_id = $thread_id;
-
-        return JobHuntingThread::select(
-            'job_hunting_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('0 AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return JobHuntingThread::with('user')
+            ->select(
+                'job_hunting_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'job_hunting_threads.message_id');
+            })
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
+                $join
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
+                    ->whereColumn('likes2.message_id', '=', 'job_hunting_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
             })
-            ->where('job_hunting_threads.thread_id', '=', $this->thread_id)
+            ->where('job_hunting_threads.hub_id', '=', $thread_id)
             ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('job_hunting_threads.message_id')
             ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\JobHuntingThread  $jobHuntingThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(JobHuntingThread $jobHuntingThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\JobHuntingThread  $jobHuntingThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, JobHuntingThread $jobHuntingThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\JobHuntingThread  $jobHuntingThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(JobHuntingThread $jobHuntingThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
@@ -4,107 +4,47 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\LectureThread;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class LectureThreadController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
      * Display the specified resource.
      *
+     * @param string $user_email
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $thread_id, int $pre_max_message_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
-        $this->thread_id = $thread_id;
-
-        return LectureThread::select(
-            'lecture_threads.*',
-            DB::raw('COUNT(likes1.user_email) AS count_user'),
-            DB::raw('0 AS user_like'),
-            'thread_image_paths.img_path'
-        )
-            ->leftjoin('likes AS likes1', function ($join) {
+        return LectureThread::with('user')
+            ->select(
+                'lecture_threads.*',
+                DB::raw('COUNT(likes1.user_email) AS count_user'),
+                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                'thread_image_paths.img_path'
+            )
+            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
                 $join
-                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->where('likes1.thread_id', '=', $thread_id)
                     ->whereColumn('likes1.message_id', '=', 'lecture_threads.message_id');
+            })
+            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
+                $join
+                    ->where('likes2.thread_id', '=', $thread_id)
+                    ->where('likes2.user_email', '=', $user_email)
+                    ->whereColumn('likes2.message_id', '=', 'lecture_threads.message_id');
             })
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.thread_id')
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.hub_id')
                     ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
             })
-            ->where('lecture_threads.thread_id', '=', $this->thread_id)
+            ->where('lecture_threads.hub_id', '=', $thread_id)
             ->where('lecture_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('lecture_threads.message_id')
             ->get();
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\LectureThread  $lectureThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(LectureThread $lectureThreads)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\LectureThread  $lectureThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, LectureThread $lectureThreads)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\LectureThread  $lectureThreads
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(LectureThread $lectureThreads)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/ThreadsController.php
@@ -5,100 +5,41 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 use App\Http\Controllers\Controller;
 use App\Models\Hub;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class ThreadsController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
      * Display the specified resource.
      *
-     * @param string $thread_id
-     * @param int $pre_max_message_id
-     *
+     * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Support\Collection | void
      */
-    public function show(string $thread_id, int $pre_max_message_id)
+    public function show(Request $request)
     {
-        $thread = Hub::where('thread_id', '=', $thread_id)
+        if (Auth::check()) {
+            $user_email = $request->user()->email;
+        } else {
+            $user_email = '';
+        }
+
+        $thread = Hub::where('id', '=', $request->thread_id)
             ->where('is_enabled', '=', 1)
             ->first();
+
         switch ($thread->thread_category_type) {
             case '学科':
-                return (new DepartmentThreadController)->show($thread_id, $pre_max_message_id);
+                return (new DepartmentThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
             case '学年':
-                return (new CollegeYearThreadController)->show($thread_id, $pre_max_message_id);
+                return (new CollegeYearThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
             case '部活':
-                return (new ClubThreadController)->show($thread_id, $pre_max_message_id);
+                return (new ClubThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
             case '授業':
-                return (new LectureThreadController)->show($thread_id, $pre_max_message_id);
+                return (new LectureThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
             case '就職':
-                return (new JobHuntingThreadController)->show($thread_id, $pre_max_message_id);
+                return (new JobHuntingThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
             default:
                 return null;
         }
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function edit($id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($id)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Dashboard/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/ThreadsController.php
@@ -38,7 +38,7 @@ class ThreadsController extends Controller
      */
     public function store(Request $request)
     {
-        if (!Hub::where('thread_id', '=', $request->thread_id)->where('is_enabled', '=', 1)->first()) return;
+        if (!Hub::where('id', '=', $request->thread_id)->where('is_enabled', '=', 1)->first()) return;
         $special_character_set = array(
             "&" => "&amp;",
             "<" => "&lt;",
@@ -60,22 +60,22 @@ class ThreadsController extends Controller
         }
 
         $message_id = 0;
-        $thread = Hub::where('thread_id', '=', $request->thread_id)->first();
+        $thread = Hub::where('id', '=', $request->thread_id)->first();
         switch ($thread->thread_category_type) {
             case '学科':
-                $message_id = (new DepartmentThreadController)->store($request->thread_id, $request->user()->name, $request->user()->email, $message);
+                $message_id = (new DepartmentThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '学年':
-                $message_id = (new CollegeYearThreadController)->store($request->thread_id, $request->user()->name, $request->user()->email, $message);
+                $message_id = (new CollegeYearThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '部活':
-                $message_id = (new ClubThreadController)->store($request->thread_id, $request->user()->name, $request->user()->email, $message);
+                $message_id = (new ClubThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '授業':
-                $message_id = (new LectureThreadController)->store($request->thread_id, $request->user()->name, $request->user()->email, $message);
+                $message_id = (new LectureThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '就職':
-                $message_id = (new JobHuntingThreadController)->store($request->thread_id, $request->user()->name, $request->user()->email, $message);
+                $message_id = (new JobHuntingThreadController)->store($request->thread_id, $request->user()->id, $message);
             default:
                 break;
         }
@@ -95,7 +95,7 @@ class ThreadsController extends Controller
             return (new NotLoggedInThreadsController)->show($request->thread_id, $request->max_message_id);
         }
 
-        $thread = Hub::where('thread_id', '=', $request->thread_id)
+        $thread = Hub::where('id', '=', $request->thread_id)
             ->where('is_enabled', '=', 1)
             ->first();
         switch ($thread->thread_category_type) {

--- a/app/Http/Controllers/Dashboard/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/ThreadsController.php
@@ -2,34 +2,12 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Http\Controllers\Controller;
-use App\Http\Controllers\Dashboard\NotLoggedIn\ThreadsController as NotLoggedInThreadsController;
+use App\Http\Controllers\Dashboard\NotLoggedIn\ThreadsController as Controller;
 use App\Models\Hub;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class ThreadsController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
     /**
      * Store a newly created resource in storage.
      *
@@ -81,69 +59,5 @@ class ThreadsController extends Controller
         }
 
         (new ThreadImagePathController)->store($request, $message_id);
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @return \Illuminate\Support\Collection | void
-     */
-    public function show(Request $request)
-    {
-        if (!Auth::check()) {
-            return (new NotLoggedInThreadsController)->show($request->thread_id, $request->max_message_id);
-        }
-
-        $thread = Hub::where('id', '=', $request->thread_id)
-            ->where('is_enabled', '=', 1)
-            ->first();
-        switch ($thread->thread_category_type) {
-            case '学科':
-                return (new DepartmentThreadController)->show($request->user()->email, $request->thread_id, $request->max_message_id);
-            case '学年':
-                return (new CollegeYearThreadController)->show($request->user()->email, $request->thread_id, $request->max_message_id);
-            case '部活':
-                return (new ClubThreadController)->show($request->user()->email, $request->thread_id, $request->max_message_id);
-            case '授業':
-                return (new LectureThreadController)->show($request->user()->email, $request->thread_id, $request->max_message_id);
-            case '就職':
-                return (new JobHuntingThreadController)->show($request->user()->email, $request->thread_id, $request->max_message_id);
-            default:
-                return null;
-        }
-    }
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function edit($id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($id)
-    {
-        //
     }
 }

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -54,4 +54,20 @@ class ClubThread extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+    /**
+     * Get the hub that owns the club thread.
+     */
+    public function hub()
+    {
+        return $this->belongsTo(Hub::class);
+    }
+
+    /**
+     * Get the user that owns the club thread.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -29,10 +29,9 @@ class ClubThread extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
+        'hub_id',
+        'user_id',
         'message_id',
-        'user_name',
-        'user_email',
         'message',
     ];
 

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -54,4 +54,21 @@ class CollegeYearThread extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+
+    /**
+     * Get the hub that owns the college year thread.
+     */
+    public function hub()
+    {
+        return $this->belongsTo(Hub::class);
+    }
+
+    /**
+     * Get the user that owns the college year thread.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -29,10 +29,9 @@ class CollegeYearThread extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
+        'hub_id',
+        'user_id',
         'message_id',
-        'user_name',
-        'user_email',
         'message',
     ];
 

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -54,4 +54,21 @@ class DepartmentThread extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+
+    /**
+     * Get the hub that owns the department thread.
+     */
+    public function hub()
+    {
+        return $this->belongsTo(Hub::class);
+    }
+
+    /**
+     * Get the user that owns the department thread.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -29,10 +29,9 @@ class DepartmentThread extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
+        'hub_id',
+        'user_id',
         'message_id',
-        'user_name',
-        'user_email',
         'message',
     ];
 

--- a/app/Models/Hub.php
+++ b/app/Models/Hub.php
@@ -47,10 +47,50 @@ class Hub extends UuidModel
     ];
 
     /**
-     * Get the access logs for the user.
+     * Get the access logs for the hub.
      */
     public function access_logs()
     {
         return $this->hasMany(AccessLog::class);
+    }
+
+    /**
+     * Get the club threads for the hub.
+     */
+    public function club_threads()
+    {
+        return $this->hasMany(ClubThread::class);
+    }
+
+    /**
+     * Get the college year threads for the hub.
+     */
+    public function college_year_threads()
+    {
+        return $this->hasMany(CollegeYearThread::class);
+    }
+
+    /**
+     * Get the department threads for the hub.
+     */
+    public function department_threads()
+    {
+        return $this->hasMany(DepartmentThread::class);
+    }
+
+    /**
+     * Get the job hunting threads for the hub.
+     */
+    public function job_hunting_threads()
+    {
+        return $this->hasMany(JobHuntingThread::class);
+    }
+
+    /**
+     * Get the lecture threads for the hub.
+     */
+    public function lecture_threads()
+    {
+        return $this->hasMany(LectureThread::class);
     }
 }

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -29,10 +29,9 @@ class JobHuntingThread extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
+        'hub_id',
+        'user_id',
         'message_id',
-        'user_name',
-        'user_email',
         'message',
     ];
 

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -54,4 +54,21 @@ class JobHuntingThread extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+
+    /**
+     * Get the hub that owns the job hunting thread.
+     */
+    public function hub()
+    {
+        return $this->belongsTo(Hub::class);
+    }
+
+    /**
+     * Get the user that owns the job hunting thread.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -29,10 +29,9 @@ class LectureThread extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
+        'hub_id',
+        'user_id',
         'message_id',
-        'user_name',
-        'user_email',
         'message',
     ];
 

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -54,4 +54,21 @@ class LectureThread extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+
+    /**
+     * Get the hub that owns the lecture thread.
+     */
+    public function hub()
+    {
+        return $this->belongsTo(Hub::class);
+    }
+
+    /**
+     * Get the user that owns the lecture thread.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -103,4 +103,61 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasMany(AccessLog::class);
     }
+
+    /**
+     * Get the club threads for the user.
+     */
+    public function club_threads()
+    {
+        return $this->hasMany(ClubThread::class);
+    }
+
+    /**
+     * Get the college year threads for the user.
+     */
+    public function college_year_threads()
+    {
+        return $this->hasMany(CollegeYearThread::class);
+    }
+
+    /**
+     * Get the department threads for the user.
+     */
+    public function department_threads()
+    {
+        return $this->hasMany(DepartmentThread::class);
+    }
+
+    /**
+     * Get the job hunting threads for the user.
+     */
+    public function job_hunting_threads()
+    {
+        return $this->hasMany(JobHuntingThread::class);
+    }
+
+    /**
+     * Get the lecture threads for the user.
+     */
+    public function lecture_threads()
+    {
+        return $this->hasMany(LectureThread::class);
+    }
+
+
+    /**
+     * Get the hub that owns the lecture thread.
+     */
+    public function hub()
+    {
+        return $this->belongsTo(Hub::class);
+    }
+
+    /**
+     * Get the user that owns the lecture thread.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/database/migrations/2022_09_05_223619_drop_column_thread_id_to_thread_tables.php
+++ b/database/migrations/2022_09_05_223619_drop_column_thread_id_to_thread_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->string('thread_id')->after('id');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->string('thread_id')->after('id');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->string('thread_id')->after('id');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->string('thread_id')->after('id');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->string('thread_id')->after('id');
+        });
+    }
+};

--- a/database/migrations/2022_09_05_223952_drop_column_user_name_to_thread_tables.php
+++ b/database/migrations/2022_09_05_223952_drop_column_user_name_to_thread_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropColumn('user_name');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropColumn('user_name');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropColumn('user_name');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropColumn('user_name');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropColumn('user_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->string('user_name')->after('id');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->string('user_name')->after('id');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->string('user_name')->after('id');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->string('user_name')->after('id');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->string('user_name')->after('id');
+        });
+    }
+};

--- a/database/migrations/2022_09_05_224103_drop_column_user_email_to_thread_tables.php
+++ b/database/migrations/2022_09_05_224103_drop_column_user_email_to_thread_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->string('user_email')->after('id');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->string('user_email')->after('id');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->string('user_email')->after('id');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->string('user_email')->after('id');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->string('user_email')->after('id');
+        });
+    }
+};

--- a/database/migrations/2022_09_05_224726_drop_column_is_validity_to_thread_tables.php
+++ b/database/migrations/2022_09_05_224726_drop_column_is_validity_to_thread_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropColumn('is_validity');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropColumn('is_validity');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropColumn('is_validity');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropColumn('is_validity');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropColumn('is_validity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->boolean('is_validity')->default(true)->after('message');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->boolean('is_validity')->default(true)->after('message');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->boolean('is_validity')->default(true)->after('message');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->boolean('is_validity')->default(true)->after('message');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->boolean('is_validity')->default(true)->after('message');
+        });
+    }
+};

--- a/database/migrations/2022_09_05_224946_add_column_hub_id_to_thread_tables.php
+++ b/database/migrations/2022_09_05_224946_add_column_hub_id_to_thread_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->foreignUuid('hub_id')->after('id')->constrained('hub');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->foreignUuid('hub_id')->after('id')->constrained('hub');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->foreignUuid('hub_id')->after('id')->constrained('hub');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->foreignUuid('hub_id')->after('id')->constrained('hub');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->foreignUuid('hub_id')->after('id')->constrained('hub');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropForeign(['hub_id']);
+            $table->dropColumn('hub_id');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropForeign(['hub_id']);
+            $table->dropColumn('hub_id');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropForeign(['hub_id']);
+            $table->dropColumn('hub_id');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropForeign(['hub_id']);
+            $table->dropColumn('hub_id');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropForeign(['hub_id']);
+            $table->dropColumn('hub_id');
+        });
+    }
+};

--- a/database/migrations/2022_09_05_225120_add_column_user_id_to_thread_tables.php
+++ b/database/migrations/2022_09_05_225120_add_column_user_id_to_thread_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('hub_id')->constrained('users');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('hub_id')->constrained('users');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('hub_id')->constrained('users');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('hub_id')->constrained('users');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('hub_id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -79,16 +79,8 @@ function reload() {
     }
   }).done(function (data) {
     for (var item in data) {
-      if (data[item]['is_validity']) {
-        // 通常
-        user = data[item]['user_name'];
-        msg = data[item]['message'];
-      } else {
-        // 管理者によって削除されていた場合
-        user = "-----";
-        msg = "<br>この投稿は管理者によって削除されました";
-      }
-
+      user = data[item]['user']['name'];
+      msg = data[item]['message'];
       show = "" + "<a " + "id='thread_message_id_" + data[item]['message_id'] + "' " + "href='#dashboard_send_comment_label' " + "type='button' " + "onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
       if (data[item]['img_path'] != null) {

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -26,15 +26,8 @@ function reload() {
         }
     }).done(function (data) {
         for (var item in data) {
-            if (data[item]['is_validity']) {
-                // 通常
-                user = data[item]['user_name'];
-                msg = data[item]['message'];
-            } else {
-                // 管理者によって削除されていた場合
-                user = "-----";
-                msg = "<br>この投稿は管理者によって削除されました";
-            }
+            user = data[item]['user']['name'];
+            msg = data[item]['message'];
 
             show = "" +
                 "<a " +

--- a/resources/views/dashboard/threads.blade.php
+++ b/resources/views/dashboard/threads.blade.php
@@ -88,7 +88,7 @@
             @if ($flag == 1)
             <tr>
                 <td>
-                    <a href="dashboard/thread/name={{ $tableName }}&id={{ $tableInfo['thread_id'] }}"
+                    <a href="dashboard/thread/name={{ $tableName }}&id={{ $tableInfo['id'] }}"
                         class="text-decoration-none">
                         {{$tableInfo["thread_name"]}}
                     </a>


### PR DESCRIPTION
## 関連

- #183 
- #186 

## やったこと

`club_threads`, `college_year_threads`, `department_threads`, `job_hunting_threads`, `lecture_threads` => `threads`

- `threads` テーブルに外部キー `hub_id`, `user_id` カラムを追加
- `threads` テーブルの `thread_id`, `user_name`, `user_email`, `is_validity` カラム削除
- Eloquent: Relationships・変更したカラムにデータ追加 が出来る様に Model の変更
- 書き込みの表示・書き込みが出来る様に Controller などを変更
- 未ログインとログイン済みのコントローラで同じ箇所があったためクラスの継承を用いる

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- ログインしていない状態で `threads` テーブルの書き込みが表示出来る事を確認
- ログインしている状態で `threads` テーブルの書き込みが表示出来る事を確認
- スレッドに書き込み・画像のアップロードが出来る事を確認

## その他

- `contact_administrators`
- `hub`
- `likes`
- `thread_categorys`
- `thread_image_paths`
- `users`
- `user_page_themas`