### PR TITLE
アクセスログの取得・表示の修正

### DIFF
--- a/app/Http/Middleware/AccessLog.php
+++ b/app/Http/Middleware/AccessLog.php
@@ -27,7 +27,7 @@ class AccessLog
         ) {
             try {
                 Log::create([
-                    'hub_id' => Hub::where('thread_id', '=', $request->thread_id)->first()->id ?? null,
+                    'hub_id' => $request->thread_id ?? null,
                     'session_id' => $request->session()->getId(),
                     'user_id' => $request->user()->id ?? null,
                     'uri' => $request->path(),

--- a/resources/views/dashboard/threads.blade.php
+++ b/resources/views/dashboard/threads.blade.php
@@ -94,7 +94,7 @@
                     </a>
                 </td>
                 <td>{{ $tableInfo["created_at"] }}</td>
-                <td>{{ $tableInfo['Access'] }}</td>
+                <td>{{ $tableInfo['access_logs_count'] }}</td>
                 <td class="hidden">{{ $tableInfo['thread_category'] }}</td>
                 <td class="hidden">{{ $tableInfo['thread_category_type'] }}</td>
             </tr>


### PR DESCRIPTION
## 関連

- #190 

## なぜこの変更をするのか

- アクセスログでスレッドが保存出来ていなかったため
- （週間・）アクセスランキングが常に0となるようになっていたため
- スレッド表示部分で閲覧回数が表示されていなかったため

## やったこと

- アクセスログでスレッドを保存出来る様に修正
- スレッド表示部分の閲覧回数が正しく表示される様に修正

## やらないこと

無し

## できるようになること（ユーザ目線）

- （週間・）アクセスランキングを見られるようになる
- スレッド表示部分で閲覧回数を見られるようになる

## できなくなること（ユーザ目線）

無し

## 動作確認

- （週間・）アクセスランキングが見られることを確認
- スレッド表示部分で閲覧回数が見られる事を確認

## その他

無し