### PR TITLE
"contact_administrators" テーブルのリレーション・その活用

### DIFF
--- a/app/Http/Controllers/Report/FormContactAdministratorController.php
+++ b/app/Http/Controllers/Report/FormContactAdministratorController.php
@@ -38,8 +38,8 @@ class FormContactAdministratorController extends Controller
     public function store(FormContactAdministratorRequest $request)
     {
         ContactAdministrator::create([
+            'user_id' => $request->user()->id,
             'type' => $request->radio_1,
-            'report_email' => $request->user()->email,
             'message' => $request->report_form_textarea
         ]);
     }

--- a/app/Models/ContactAdministrator.php
+++ b/app/Models/ContactAdministrator.php
@@ -29,8 +29,8 @@ class ContactAdministrator extends Model
      * @var string[]
      */
     protected $fillable = [
+        'user_id',
         'type',
-        'report_email',
         'message',
     ];
 
@@ -52,4 +52,12 @@ class ContactAdministrator extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+    /**
+     * Get the user that owns the contact administrator.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -121,6 +121,14 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
+     * Get the contact administrators for the user.
+     */
+    public function contact_administrators()
+    {
+        return $this->hasMany(ContactAdministrator::class);
+    }
+
+    /**
      * Get the department threads for the user.
      */
     public function department_threads()

--- a/database/migrations/2022_09_15_231034_add_column_user_id_to_contact_administrators_table.php
+++ b/database/migrations/2022_09_15_231034_add_column_user_id_to_contact_administrators_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_09_15_231432_drop_column_report_email_to_contact_administrators_table.php
+++ b/database/migrations/2022_09_15_231432_drop_column_report_email_to_contact_administrators_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->dropColumn('report_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->string('report_email')->after('user_id');
+        });
+    }
+};


### PR DESCRIPTION
## 関連

- #183 
- #186 

## やったこと

- `contact_administrators` テーブルに外部キー `user_id` を追加・`report_email` カラムの削除
- Eloquent: Relationships を利用・変更したカラムにデータを挿入，出来る様にモデルの変更
- 管理者に報告が出来る様にコントローラの変更

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- 報告ページで報告する事でデータベースに報告内容が保存される事を確認

## その他

- `hub`
- `likes`
- `thread_categorys`
- `thread_image_paths`
- `users`
- `user_page_themas`