### PR TITLE
"likes" テーブルのリレーション・その活用

### DIFF
--- a/app/Http/Controllers/Dashboard/LikeController.php
+++ b/app/Http/Controllers/Dashboard/LikeController.php
@@ -3,7 +3,14 @@
 namespace App\Http\Controllers\Dashboard;
 
 use App\Http\Controllers\Controller;
+use App\Models\ClubThread;
+use App\Models\CollegeYearThread;
+use App\Models\DepartmentThread;
+use App\Models\Hub;
+use App\Models\JobHuntingThread;
+use App\Models\LectureThread;
 use App\Models\Like;
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Http\Request;
 
 class LikeController extends Controller
@@ -36,16 +43,70 @@ class LikeController extends Controller
      */
     public function store(Request $request)
     {
-        Like::insertOrIgnore([
-            'thread_id' => $request->thread_id,
-            'message_id' => $request->message_id,
-            'user_email' => $request->user()->email,
-            'created_at' => now(),
-        ]);
+        $thread = Hub::with('thread_category')
+            ->where('id', '=', $request->thread_id)
+            ->where('is_enabled', '=', 1)
+            ->first();
 
-        return Like::where('thread_id', '=', $request->thread_id)
-            ->where('message_id', '=', $request->message_id)
-            ->count();
+        switch ($thread->thread_category->category_type) {
+            case '部活':
+                $club_thread_id = ClubThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::insertOrIgnore([
+                    'club_thread_id' => $club_thread_id,
+                    'user_id' => $request->user()->id
+                ]);
+                return Like::where('club_thread_id', '=', $club_thread_id)->count();
+
+            case '学年':
+                $college_year_thread_id = CollegeYearThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::insertOrIgnore([
+                    'college_year_thread_id' => $college_year_thread_id,
+                    'user_id' => $request->user()->id
+                ]);
+                return Like::where('college_year_thread_id', '=', $college_year_thread_id)->count();
+
+            case '学科':
+                $department_thread_id = DepartmentThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::insertOrIgnore([
+                    'department_thread_id' => $department_thread_id,
+                    'user_id' => $request->user()->id
+                ]);
+                return Like::where('department_thread_id', '=', $department_thread_id)->count();
+
+            case '就職':
+                $job_hunting_thread_id = JobHuntingThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::insertOrIgnore([
+                    'job_hunting_thread_id' => $job_hunting_thread_id,
+                    'user_id' => $request->user()->id
+                ]);
+                return Like::where('job_hunting_thread_id', '=', $job_hunting_thread_id)->count();
+
+            case '授業':
+                $lecture_thread_id = LectureThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::insertOrIgnore([
+                    'lecture_thread_id' => $lecture_thread_id,
+                    'user_id' => $request->user()->id
+                ]);
+                return Like::where('lecture_thread_id', '=', $lecture_thread_id)->count();
+
+            default:
+                return 0;
+        }
     }
 
     /**
@@ -90,13 +151,64 @@ class LikeController extends Controller
      */
     public function destroy(Request $request)
     {
-        Like::where('thread_id', '=', $request->thread_id)
-            ->where('message_id', '=', $request->message_id)
-            ->where('user_email', '=', $request->user()->email)
-            ->delete();
+        $thread = Hub::with('thread_category')
+            ->where('id', '=', $request->thread_id)
+            ->where('is_enabled', '=', 1)
+            ->first();
 
-        return Like::where('thread_id', '=', $request->thread_id)
-            ->where('message_id', '=', $request->message_id)
-            ->count();
+        switch ($thread->thread_category->category_type) {
+            case '部活':
+                $club_thread_id = ClubThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::where('club_thread_id', '=', $club_thread_id)
+                    ->where('user_id', '=', $request->user()->id)
+                    ->delete();
+                return Like::where('club_thread_id', '=', $club_thread_id)->count();
+
+            case '学年':
+                $college_year_thread_id = CollegeYearThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::where('college_year_thread_id', '=', $college_year_thread_id)
+                    ->where('user_id', '=', $request->user()->id)
+                    ->delete();
+                return Like::where('college_year_thread_id', '=', $college_year_thread_id)->count();
+
+            case '学科':
+                $department_thread_id = DepartmentThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::where('department_thread_id', '=', $department_thread_id)
+                    ->where('user_id', '=', $request->user()->id)
+                    ->delete();
+                return Like::where('department_thread_id', '=', $department_thread_id)->count();
+
+            case '就職':
+                $job_hunting_thread_id = JobHuntingThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::where('job_hunting_thread_id', '=', $job_hunting_thread_id)
+                    ->where('user_id', '=', $request->user()->id)
+                    ->delete();
+                return Like::where('job_hunting_thread_id', '=', $job_hunting_thread_id)->count();
+
+            case '授業':
+                $lecture_thread_id = LectureThread::where('hub_id', '=', $request->thread_id)
+                    ->where('message_id', '=', $request->message_id)
+                    ->first()
+                    ->id;
+                Like::where('lecture_thread_id', '=', $lecture_thread_id)
+                    ->where('user_id', '=', $request->user()->id)
+                    ->delete();
+                return Like::where('lecture_thread_id', '=', $lecture_thread_id)->count();
+
+            default:
+                return 0;
+        }
     }
 }

--- a/app/Http/Controllers/Dashboard/LikeController.php
+++ b/app/Http/Controllers/Dashboard/LikeController.php
@@ -54,7 +54,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'club_thread_id' => $club_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -65,7 +65,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'college_year_thread_id' => $college_year_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -76,7 +76,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'department_thread_id' => $department_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -87,7 +87,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'job_hunting_thread_id' => $job_hunting_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -98,7 +98,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'lecture_thread_id' => $lecture_thread_id,
                     'user_id' => $request->user()->id
                 ]);

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
@@ -4,39 +4,27 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\ClubThread;
-use Illuminate\Support\Facades\DB;
 
 class ClubThreadController extends Controller
 {
     /**
      * Display the specified resource.
      *
-     * @param string $user_email
+     * @param string $user_id
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
+    public function show(string $user_id, string $thread_id, int $pre_max_message_id)
     {
-        return ClubThread::with('user')
-            ->select(
-                'club_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'club_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'club_threads.message_id');
-            })
+        return ClubThread::with([
+            'user',
+            'likes' => function ($query) use ($user_id) {
+                $query->where('user_id', '=', $user_id);
+            }
+        ])
+            ->withCount('likes')
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
                     ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.hub_id')

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
@@ -20,19 +20,15 @@ class ClubThreadController extends Controller
     {
         return ClubThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
-            })
-            ->where('club_threads.hub_id', '=', $thread_id)
-            ->where('club_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('club_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
@@ -4,39 +4,27 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\CollegeYearThread;
-use Illuminate\Support\Facades\DB;
 
 class CollegeYearThreadController extends Controller
 {
     /**
      * Display the specified resource.
      *
-     * @param string $user_email
+     * @param string $user_id
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
+    public function show(string $user_id, string $thread_id, int $pre_max_message_id)
     {
-        return CollegeYearThread::with('user')
-            ->select(
-                'college_year_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'college_year_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'college_year_threads.message_id');
-            })
+        return CollegeYearThread::with([
+            'user',
+            'likes' => function ($query) use ($user_id) {
+                $query->where('user_id', '=', $user_id);
+            }
+        ])
+            ->withCount('likes')
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
                     ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.hub_id')

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
@@ -20,19 +20,15 @@ class CollegeYearThreadController extends Controller
     {
         return CollegeYearThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
-            })
-            ->where('college_year_threads.hub_id', '=', $thread_id)
-            ->where('college_year_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('college_year_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
@@ -20,19 +20,15 @@ class DepartmentThreadController extends Controller
     {
         return DepartmentThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
-            })
-            ->where('department_threads.hub_id', '=', $thread_id)
-            ->where('department_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('department_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
@@ -4,39 +4,27 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\DepartmentThread;
-use Illuminate\Support\Facades\DB;
 
 class DepartmentThreadController extends Controller
 {
     /**
      * Display the specified resource.
      *
-     * @param string $user_email
+     * @param string $user_id
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
+    public function show(string $user_id, string $thread_id, int $pre_max_message_id)
     {
-        return DepartmentThread::with('user')
-            ->select(
-                'department_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'department_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'department_threads.message_id');
-            })
+        return DepartmentThread::with([
+            'user',
+            'likes' => function ($query) use ($user_id) {
+                $query->where('user_id', '=', $user_id);
+            }
+        ])
+            ->withCount('likes')
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
                     ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.hub_id')

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
@@ -4,39 +4,27 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\JobHuntingThread;
-use Illuminate\Support\Facades\DB;
 
 class JobHuntingThreadController extends Controller
 {
     /**
      * Display the specified resource.
      *
-     * @param string $user_email
+     * @param string $user_id
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
+    public function show(string $user_id, string $thread_id, int $pre_max_message_id)
     {
-        return JobHuntingThread::with('user')
-            ->select(
-                'job_hunting_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'job_hunting_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'job_hunting_threads.message_id');
-            })
+        return JobHuntingThread::with([
+            'user',
+            'likes' => function ($query) use ($user_id) {
+                $query->where('user_id', '=', $user_id);
+            }
+        ])
+            ->withCount('likes')
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
                     ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.hub_id')

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
@@ -20,19 +20,15 @@ class JobHuntingThreadController extends Controller
     {
         return JobHuntingThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
-            })
-            ->where('job_hunting_threads.hub_id', '=', $thread_id)
-            ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('job_hunting_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
@@ -4,39 +4,27 @@ namespace App\Http\Controllers\Dashboard\NotLoggedIn;
 
 use App\Http\Controllers\Controller;
 use App\Models\LectureThread;
-use Illuminate\Support\Facades\DB;
 
 class LectureThreadController extends Controller
 {
     /**
      * Display the specified resource.
      *
-     * @param string $user_email
+     * @param string $user_id
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
      * @return \Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
+    public function show(string $user_id, string $thread_id, int $pre_max_message_id)
     {
-        return LectureThread::with('user')
-            ->select(
-                'lecture_threads.*',
-                DB::raw('COUNT(likes1.user_email) AS count_user'),
-                DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
-                'thread_image_paths.img_path'
-            )
-            ->leftjoin('likes AS likes1', function ($join) use ($thread_id) {
-                $join
-                    ->where('likes1.thread_id', '=', $thread_id)
-                    ->whereColumn('likes1.message_id', '=', 'lecture_threads.message_id');
-            })
-            ->leftjoin('likes AS likes2', function ($join) use ($thread_id, $user_email) {
-                $join
-                    ->where('likes2.thread_id', '=', $thread_id)
-                    ->where('likes2.user_email', '=', $user_email)
-                    ->whereColumn('likes2.message_id', '=', 'lecture_threads.message_id');
-            })
+        return LectureThread::with([
+            'user',
+            'likes' => function ($query) use ($user_id) {
+                $query->where('user_id', '=', $user_id);
+            }
+        ])
+            ->withCount('likes')
             ->leftjoin('thread_image_paths', function ($join) {
                 $join
                     ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.hub_id')

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
@@ -20,19 +20,15 @@ class LectureThreadController extends Controller
     {
         return LectureThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
-            })
-            ->where('lecture_threads.hub_id', '=', $thread_id)
-            ->where('lecture_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('lecture_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/ThreadsController.php
@@ -18,9 +18,9 @@ class ThreadsController extends Controller
     public function show(Request $request)
     {
         if (Auth::check()) {
-            $user_email = $request->user()->email;
+            $user_id = $request->user()->id;
         } else {
-            $user_email = '';
+            $user_id = '';
         }
 
         $thread = Hub::with('thread_category')
@@ -29,16 +29,16 @@ class ThreadsController extends Controller
             ->first();
 
         switch ($thread->thread_category->category_type) {
-            case '学科':
-                return (new DepartmentThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
-            case '学年':
-                return (new CollegeYearThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
             case '部活':
-                return (new ClubThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
+                return (new ClubThreadController)->show($user_id, $request->thread_id, $request->max_message_id);
+            case '学年':
+                return (new CollegeYearThreadController)->show($user_id, $request->thread_id, $request->max_message_id);
+            case '学科':
+                return (new DepartmentThreadController)->show($user_id, $request->thread_id, $request->max_message_id);
             case '授業':
-                return (new LectureThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
+                return (new LectureThreadController)->show($user_id, $request->thread_id, $request->max_message_id);
             case '就職':
-                return (new JobHuntingThreadController)->show($user_email, $request->thread_id, $request->max_message_id);
+                return (new JobHuntingThreadController)->show($user_id, $request->thread_id, $request->max_message_id);
             default:
                 return null;
         }

--- a/app/Http/Controllers/Dashboard/ThreadImagePathController.php
+++ b/app/Http/Controllers/Dashboard/ThreadImagePathController.php
@@ -3,8 +3,14 @@
 namespace App\Http\Controllers\Dashboard;
 
 use App\Http\Controllers\Controller;
+use App\Models\ClubThread;
+use App\Models\CollegeYearThread;
+use App\Models\DepartmentThread;
+use App\Models\JobHuntingThread;
+use App\Models\LectureThread;
 use App\Models\ThreadImagePath;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
 use Intervention\Image\Facades\Image;
 use Illuminate\Support\Facades\Storage;
@@ -34,28 +40,81 @@ class ThreadImagePathController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\UploadedFile $img
+     * @param string $user_id
+     * @param string $thread_id
      * @param int $message_id
+     * @param string $category_type
      *
      * @return void
      */
-    public function store(Request $request, int $message_id)
+    public function store(UploadedFile $img = null, string $user_id, string $thread_id, int $message_id, string $category_type)
     {
-        if ($request->file('img')) {
-            $img = Image::make($request->file('img'))->encode('jpg')->orientate()->save();
+        if ($img) {
+            $img = Image::make($img)->encode('jpg')->orientate()->save();
 
             $size = $img->filesize();
             $path = 'public/images/thread_message/' . str_replace('-', '', Str::uuid()) . '.jpg';
             Storage::put($path, $img);
 
             if ($path) {
-                ThreadImagePath::create([
-                    'thread_id' => $request->thread_id,
-                    'message_id' => $message_id,
-                    'user_email' => $request->user()->email,
-                    'img_path' => $path,
-                    'img_size' => $size
-                ]);
+                switch ($category_type) {
+                    case '部活':
+                        ThreadImagePath::create([
+                            'club_thread_id' => ClubThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '学年':
+                        ThreadImagePath::create([
+                            'college_year_thread_id' => CollegeYearThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '学科':
+                        ThreadImagePath::create([
+                            'department_thread_id' => DepartmentThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '就職':
+                        ThreadImagePath::create([
+                            'job_hunting_thread_id' => JobHuntingThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '授業':
+                        ThreadImagePath::create([
+                            'lecture_thread_id' => LectureThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                }
             }
 
             $img->destroy();

--- a/app/Http/Controllers/Dashboard/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/ThreadsController.php
@@ -44,24 +44,25 @@ class ThreadsController extends Controller
             ->first();
 
         switch ($thread->thread_category->category_type) {
-            case '学科':
-                $message_id = (new DepartmentThreadController)->store($request->thread_id, $request->user()->id, $message);
+            case '部活':
+                $message_id = (new ClubThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '学年':
                 $message_id = (new CollegeYearThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
-            case '部活':
-                $message_id = (new ClubThreadController)->store($request->thread_id, $request->user()->id, $message);
+            case '学科':
+                $message_id = (new DepartmentThreadController)->store($request->thread_id, $request->user()->id, $message);
+                break;
+            case '就職':
+                $message_id = (new JobHuntingThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '授業':
                 $message_id = (new LectureThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
-            case '就職':
-                $message_id = (new JobHuntingThreadController)->store($request->thread_id, $request->user()->id, $message);
             default:
                 break;
         }
 
-        (new ThreadImagePathController)->store($request, $message_id);
+        (new ThreadImagePathController)->store($request->file('img'), $request->user()->id, $request->thread_id, $message_id, $thread->thread_category->category_type);
     }
 }

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -69,4 +69,12 @@ class ClubThread extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Get the likes for the club thread.
+     */
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -77,4 +77,12 @@ class ClubThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the club thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -70,4 +70,12 @@ class CollegeYearThread extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Get the likes for the club thread.
+     */
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -78,4 +78,12 @@ class CollegeYearThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the college year thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -70,4 +70,12 @@ class DepartmentThread extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Get the likes for the club thread.
+     */
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -78,4 +78,12 @@ class DepartmentThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the department thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -78,4 +78,12 @@ class JobHuntingThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the job hunting thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -70,4 +70,12 @@ class JobHuntingThread extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Get the likes for the club thread.
+     */
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -70,4 +70,12 @@ class LectureThread extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Get the likes for the club thread.
+     */
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -78,4 +78,12 @@ class LectureThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the lecture thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -29,9 +29,12 @@ class Like extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
-        'message_id',
-        'user_email',
+        'club_thread_id',
+        'college_year_thread_id',
+        'department_thread_id',
+        'job_hunting_thread_id',
+        'lecture_thread_id',
+        'user_id'
     ];
 
     /**
@@ -52,4 +55,44 @@ class Like extends Model
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+    /**
+     * Get the club thread that owns the like.
+     */
+    public function club_thread()
+    {
+        return $this->belongsTo(ClubThread::class);
+    }
+
+    /**
+     * Get the college year thread that owns the like.
+     */
+    public function college_year_thread()
+    {
+        return $this->belongsTo(CollegeYearThread::class);
+    }
+
+    /**
+     * Get the department thread that owns the like.
+     */
+    public function department_thread()
+    {
+        return $this->belongsTo(DepartmentThread::class);
+    }
+
+    /**
+     * Get the job hunting thread that owns the like.
+     */
+    public function job_hunting_thread()
+    {
+        return $this->belongsTo(JobHuntingThread::class);
+    }
+
+    /**
+     * Get the user that owns the like.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/ThreadImagePath.php
+++ b/app/Models/ThreadImagePath.php
@@ -29,22 +29,14 @@ class ThreadImagePath extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
-        'message_id',
-        'user_email',
+        'club_thread_id',
+        'college_year_thread_id',
+        'department_thread_id',
+        'job_hunting_thread_id',
+        'lecture_thread_id',
+        'user_id',
         'img_path',
         'img_size',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array
-     */
-    protected $hidden = [
-        'thread_id',
-        'img_path',
-        'img_size'
     ];
 
     /**
@@ -53,7 +45,47 @@ class ThreadImagePath extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+    /**
+     * Get the club thread that owns the thread image path.
+     */
+    public function club_thread()
+    {
+        return $this->belongsTo(ClubThread::class);
+    }
+
+    /**
+     * Get the college year thread that owns the thread image path.
+     */
+    public function college_year_thread()
+    {
+        return $this->belongsTo(CollegeYearThread::class);
+    }
+
+    /**
+     * Get the department thread that owns the thread image path.
+     */
+    public function department_thread()
+    {
+        return $this->belongsTo(DepartmentThread::class);
+    }
+
+    /**
+     * Get the job hunting thread that owns the thread image path.
+     */
+    public function job_hunting_thread()
+    {
+        return $this->belongsTo(JobHuntingThread::class);
+    }
+
+    /**
+     * Get the lecture thread that owns the thread image path.
+     */
+    public function lecture_thread()
+    {
+        return $this->belongsTo(LectureThread::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -71,7 +71,9 @@ class User extends Authenticatable implements MustVerifyEmail
      * @var array
      */
     protected $casts = [
-        'email_verified_at' => 'datetime',
+        'email_verified_at' => 'datetime:Y-m-d H:i:s',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -159,4 +159,12 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasMany(LectureThread::class);
     }
+
+    /**
+     * Get the likes for the user.
+     */
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/database/migrations/2022_10_13_214551_add_column_club_thread_id_to_likes_table.php
+++ b/database/migrations/2022_10_13_214551_add_column_club_thread_id_to_likes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->foreignId('club_thread_id')->nullable(true)->after('id')->constrained('club_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['club_thread_id']);
+            $table->dropColumn('club_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_13_214605_add_column_college_year_thread_id_to_likes_table.php
+++ b/database/migrations/2022_10_13_214605_add_column_college_year_thread_id_to_likes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->foreignId('college_year_thread_id')->nullable(true)->after('club_thread_id')->constrained('college_year_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['college_year_thread_id']);
+            $table->dropColumn('college_year_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_13_214616_add_column_department_thread_id_to_likes_table.php
+++ b/database/migrations/2022_10_13_214616_add_column_department_thread_id_to_likes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->foreignId('department_thread_id')->nullable(true)->after('college_year_thread_id')->constrained('department_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['department_thread_id']);
+            $table->dropColumn('department_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_13_214636_add_column_job_hunting_thread_id_to_likes_table.php
+++ b/database/migrations/2022_10_13_214636_add_column_job_hunting_thread_id_to_likes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->foreignId('job_hunting_thread_id')->nullable(true)->after('department_thread_id')->constrained('job_hunting_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['job_hunting_thread_id']);
+            $table->dropColumn('job_hunting_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_13_214646_add_column_lecture_thread_id_to_likes_table.php
+++ b/database/migrations/2022_10_13_214646_add_column_lecture_thread_id_to_likes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->foreignId('lecture_thread_id')->nullable(true)->after('job_hunting_thread_id')->constrained('lecture_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['lecture_thread_id']);
+            $table->dropColumn('lecture_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_14_214953_add_column_user_id_to_likes_table.php
+++ b/database/migrations/2022_10_14_214953_add_column_user_id_to_likes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('lecture_thread_id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_14_215322_drop_column_thread_id_to_likes_table.php
+++ b/database/migrations/2022_10_14_215322_drop_column_thread_id_to_likes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->string('thread_id')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_14_215416_drop_column_message_id_to_likes_table.php
+++ b/database/migrations/2022_10_14_215416_drop_column_message_id_to_likes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropColumn('message_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->string('message_id')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_14_215433_drop_column_user_email_to_likes_table.php
+++ b/database/migrations/2022_10_14_215433_drop_column_user_email_to_likes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->string('user_email')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151605_add_column_club_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151605_add_column_club_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('club_thread_id')->nullable(true)->after('id')->constrained('club_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['club_thread_id']);
+            $table->dropColumn('club_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151621_add_column_college_year_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151621_add_column_college_year_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('college_year_thread_id')->nullable(true)->after('club_thread_id')->constrained('college_year_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['college_year_thread_id']);
+            $table->dropColumn('college_year_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151640_add_column_department_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151640_add_column_department_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('department_thread_id')->nullable(true)->after('college_year_thread_id')->constrained('department_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['department_thread_id']);
+            $table->dropColumn('department_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151714_add_column_job_hunting_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151714_add_column_job_hunting_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('job_hunting_thread_id')->nullable(true)->after('department_thread_id')->constrained('job_hunting_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['job_hunting_thread_id']);
+            $table->dropColumn('job_hunting_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151738_add_column_lecture_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151738_add_column_lecture_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('lecture_thread_id')->nullable(true)->after('job_hunting_thread_id')->constrained('lecture_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['lecture_thread_id']);
+            $table->dropColumn('lecture_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_153505_add_column_user_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_153505_add_column_user_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('lecture_thread_id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_154007_drop_column_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_154007_drop_column_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->string('thread_id')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_154030_drop_column_message_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_154030_drop_column_message_id_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropColumn('message_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->string('message_id')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_154055_drop_column_user_email_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_154055_drop_column_user_email_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->string('user_email')->after('user_id');
+        });
+    }
+};

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -83,8 +83,8 @@ function reload() {
       msg = data[item]['message'];
       show = "" + "<a " + "id='thread_message_id_" + data[item]['message_id'] + "' " + "href='#dashboard_send_comment_label' " + "type='button' " + "onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
-      if (data[item]['img_path'] != null) {
-        show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";
+      if (data[item]['thread_image_path'] !== null) {
+        show += "" + "<p>" + "<img src='" + url + data[item]['thread_image_path']['img_path'].replace('public', '/storage') + "'>" + "</p>";
       }
 
       show += "" + "<br>" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' ";

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -89,7 +89,7 @@ function reload() {
 
       show += "" + "<br>" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' ";
 
-      if (data[item]['user_like'] == 0) {
+      if (data[item]['likes']['length'] === 0) {
         // いいねが押されていない場合
         show += "class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>";
       } else {
@@ -97,7 +97,7 @@ function reload() {
         show += "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>";
       }
 
-      show += "" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>" + "<hr>";
+      show += "" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['likes_count'] + "</dev>" + "<hr>";
       displayArea.insertAdjacentHTML('afterbegin', show);
       max_message_id = data[item]['message_id'];
     }

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -43,10 +43,10 @@ function reload() {
                 msg +
                 "</p>";
 
-            if (data[item]['img_path'] != null) {
+            if (data[item]['thread_image_path'] !== null) {
                 show += "" +
                     "<p>" +
-                    "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" +
+                    "<img src='" + url + data[item]['thread_image_path']['img_path'].replace('public', '/storage') + "'>" +
                     "</p>";
             }
 

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -56,7 +56,7 @@ function reload() {
                 "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " +
                 "type='button' ";
 
-            if (data[item]['user_like'] == 0) {
+            if (data[item]['likes']['length'] === 0) {
                 // いいねが押されていない場合
                 show += "class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>";
             } else {
@@ -68,7 +68,7 @@ function reload() {
                 "like" +
                 "</button> " +
                 "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" +
-                data[item]['count_user'] +
+                data[item]['likes_count'] +
                 "</dev>" +
                 "<hr>";
 


### PR DESCRIPTION
## 関連

- #183 
- #186 

## やったこと

- `likes` テーブルに外部キー `club_thread_id`, `college_year_thread_id`, `department_thread_id`, `job_hunting_thread_id`, `lecture_thread_id`, `user_id` を追加
- `likes` テーブルの `thread_id`, `message_id`, `user_email` カラムを削除
- Eloquent: Relationships を利用・変更したカラムにデータを挿入，出来る様にモデルの変更
- スレッドの取得・書き込み・いいね機能が動作するように変更

## やらないこと

- スレッドに書き込んだ画像の取得が動作するように変更すること

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

- スレッドに書き込んだ画像の閲覧ができなくなる

## 動作確認

- 全ての大枠カテゴリでスレッド作成ができることを確認
- 全ての大枠カテゴリでスレッドの閲覧・書き込み・いいねができることを確認

### 課題

- スレッドに書き込んだ画像の閲覧ができない

## その他

リレーション未設定テーブル

- `thread_categorys`
- `thread_image_paths`
- `users`
- `user_page_themas`