### PR TITLE
開発用セットアップの変更

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -11,7 +11,7 @@ chmod -R 777 public/uploads
 composer install
 npm install
 
-sed -ie "s/DB_HOST=127.0.0.1/DB_HOST=hira-chan_mysql/g" /usr/src/app/.env
+sed -ie "s/DB_HOST=127.0.0.1/DB_HOST=hira-chan_mariadb/g" /usr/src/app/.env
 sed -ie "s/DB_DATABASE=/DB_DATABASE=forum/g" /usr/src/app/.env
 sed -ie "s/DB_PASSWORD=/DB_PASSWORD=rootpass/g" /usr/src/app/.env
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,25 +1,33 @@
 #!/bin/bash
 
+# Place env file in project root
 cp /usr/src/app/.env.example /usr/src/app/.env
 
+# Creation of a directory to store images uploaded to the thread
+mkdir storage/app/public
 mkdir storage/app/public/images
 mkdir storage/app/public/images/thread_message
+
+# Change directory permissions to allow laravel to write
 chmod -R 777 storage
 chmod -R 777 bootstrap/cache
-chmod -R 777 public/uploads
 
+# Install PHP and Node packages used for development
 composer install
 npm install
 
+# Modify env file to make database available
 sed -ie "s/DB_HOST=127.0.0.1/DB_HOST=hira-chan_mariadb/g" /usr/src/app/.env
 sed -ie "s/DB_DATABASE=/DB_DATABASE=forum/g" /usr/src/app/.env
 sed -ie "s/DB_PASSWORD=/DB_PASSWORD=rootpass/g" /usr/src/app/.env
 
+# Executing commands to run hira-chan
 php artisan key:generate
 php artisan migrate
 php artisan db:seed
 php artisan storage:link
 
+# Delete unnecessary files created when copying env files
 rm /usr/src/app/.enve
 
 exit 0

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=hira-chan
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       db:
-        image: mysql:8.0
+        image: mariadb:10.10.2
         ports:
           - 3306:3306
         env:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -6,24 +6,36 @@ ENV LANG=C.UTF-8
 
 RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    openssh-client \
-    zlib1g-dev \
-    libzip-dev \
-    libpng-dev \
-    libjpeg62-turbo-dev \
-    libfreetype6-dev \
-    default-mysql-client \
-    gnupg \
-    bsd-mailx \
-    libsasl2-modules \
-    && DEBIAN_FRONTEND=noninteractive apt-get install postfix -y \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install mysqli pdo_mysql zip opcache gd exif \
-    && useradd -m -s /bin/bash dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git \
+        openssh-client \
+        default-mysql-client \
+        libfreetype6-dev \
+        libjpeg-dev \
+        libpng-dev \
+        libzip-dev \
+        zlib1g-dev \
+    ; \
+    \
+    DEBIAN_FRONTEND=noninteractive apt-get install postfix -y \
+    ; \
+	docker-php-ext-configure gd --with-freetype --with-jpeg; \
+	docker-php-ext-install \
+		bcmath \
+		exif \
+		gd \
+		mysqli \
+		opcache \
+		pdo_mysql \
+		zip \
+    ; \
+    \
+    useradd -m -s /bin/bash dev \
+    ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/*;
 
 COPY --from=node:16.18.0-slim /usr/local /usr/local
 COPY --from=composer:2.4.3 /usr/bin/composer /usr/bin/composer

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       MARIADB_ROOT_PASSWORD: rootpass
       MARIADB_PASSWORD: pass
       TZ: Asia/Tokyo
-    command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     ports:
       - 3306:3306
     tty: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ..:/usr/src/app
     depends_on:
-      - hira-chan_mysql
+      - hira-chan_mariadb
     tty: true
 
   hira-chan_nginx:
@@ -35,19 +35,19 @@ services:
       - hira-chan_phpmyadmin
     tty: true
 
-  hira-chan_mysql:
-    image: hira-chan_mysql:latest
-    container_name: hira-chan_mysql
+  hira-chan_mariadb:
+    image: hira-chan_mariadb:latest
+    container_name: hira-chan_mariadb
     build:
       context: ..
-      dockerfile: ./docker/mysql/Dockerfile
+      dockerfile: ./docker/mariadb/Dockerfile
     environment:
-      MYSQL_DATABASE: forum
-      MYSQL_USER: user
-      MYSQL_ROOT_PASSWORD: rootpass
-      MYSQL_PASSWORD: pass
+      MARIADB_DATABASE: forum
+      MARIADB_USER: user
+      MARIADB_ROOT_PASSWORD: rootpass
+      MARIADB_PASSWORD: pass
       TZ: Asia/Tokyo
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     ports:
       - 3306:3306
     tty: true
@@ -60,7 +60,7 @@ services:
       dockerfile: ./docker/phpmyadmin/Dockerfile
     environment:
       PMA_ARBITRARY: 1
-      PMA_HOST: hira-chan_mysql
+      PMA_HOST: hira-chan_mariadb
       PMA_USER: root
       PMA_PASSWORD: rootpass
       PMA_VERBOSE: phpmyadmin
@@ -69,7 +69,7 @@ services:
     volumes:
       - hira-chan_phpmyadmin-vol:/var/www/html
     depends_on:
-      - hira-chan_mysql
+      - hira-chan_mariadb
     tty: true
 
 volumes:

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb:10.10.2

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,1 +1,0 @@
-FROM mysql:8.0.31-debian


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- デフォルトのアプリ名の変更するため
- 本番環境で使用するデータベースがMysqlからMariaDBへと変更になったため
- セットアップ後にスレッドにアップロードされた画像が取得出来なかったため
- Laravelのデプロイに必要なシステム要件を満たせていなかったため

## やったこと

- `.env.example` でアプリ名を `hira-chan` に変更
- `docker` フォルダ内のファイルを変更し，開発で使用するDBイメージをMariaDBに変更
- devcontaienrの始めに実行されるスクリプトでスレッドにアップロードされた画像を保存するディレクトリを作成
- 同スクリプトでlaravel-adminで必要だったコマンド部分を削除
- laravelフレームワークのサーバ要件を満たすように `hira-chan_app` のDockerfileを変更

## やらないこと

無し

## できるようになること ~~（ユーザ目線）~~ （開発者目線）

- devcontainerでのセットアップ直後にスレッドにアップロードされた画像を取得出来る様に

## できなくなること ~~（ユーザ目線）~~ （開発者目線）

無し

## 動作確認

- devcontainerのセットアップが正常に実行出来る事を確認
- セットアップ後直後にスレッドに，アップロードされた画像の取得が出来る事を確認

## その他

無し