### PR TITLE
開発用コンテナでgitコマンドの補完が行われるように変更

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# git command completion
+wget https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash -O ~/.git-completion.bash
+cat <<EOF >> ~/.bashrc
+
+# git command completion
+source $HOME/.git-completion.bash
+EOF
+
 # Place env file in project root
 cp /usr/src/app/.env.example /usr/src/app/.env
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -4,12 +4,16 @@ WORKDIR /usr/src/app
 
 ENV LANG=C.UTF-8
 
+# Faster apt commands
 RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.list
 
-RUN apt-get update; \
+RUN \
+    # # Install Required Linux Packages
+    apt-get update; \
     apt-get install -y --no-install-recommends \
         git \
         openssh-client \
+        wget \
         default-mysql-client \
         libfreetype6-dev \
         libjpeg-dev \
@@ -17,9 +21,13 @@ RUN apt-get update; \
         libzip-dev \
         zlib1g-dev \
     ; \
-    \
     DEBIAN_FRONTEND=noninteractive apt-get install postfix -y \
     ; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/* \
+    ; \
+    # # Install Required PHP extensions
 	docker-php-ext-configure gd --with-freetype --with-jpeg; \
 	docker-php-ext-install \
 		bcmath \
@@ -31,13 +39,12 @@ RUN apt-get update; \
 		zip \
     ; \
     \
-    useradd -m -s /bin/bash dev \
-    ; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	apt-get clean; \
-	rm -rf /var/lib/apt/lists/*;
+    useradd -m -s /bin/bash dev
 
+# Enabling composer and npm in containers
 COPY --from=node:16.18.0-slim /usr/local /usr/local
 COPY --from=composer:2.4.3 /usr/bin/composer /usr/bin/composer
+
+# Place configuration files in containers
 COPY ./docker/app/php/php.ini /usr/local/etc/php/php.ini
 COPY ./docker/app/postfix/main.cf /etc/postfix/main.cf


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- 開発用コンテナでgitコマンドの補完が行われず不便だったため

## やったこと

- git補完のためのシェルダウンロード
- シェルの適応

## やらないこと

無し

## できるようになること ~~（ユーザ目線）~~ （開発者目線）

- コンテナ内でTabキーによりgitコマンドの補完が出来る様になる

## できなくなること ~~（ユーザ目線）~~ （開発者目線）

無し

## 動作確認

- コンテナ内でTabキーによりgitコマンドの補完が出来る事を確認

## その他

無し