### PR TITLE
管理画面でユーザのEmail検証が行えなかったのを修正

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -53,6 +53,7 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
         'user_page_theme_id',
         'name',
         'email',
+        'email_verified_at',
         'password',
     ];
 


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- 管理画面でEmailの検証が行えなかったから

## やったこと

- Model の User ファイルで，`fillable` の項目に `email_verified_at` を追加

## やらないこと

無し

## できるようになること ~~（ユーザ目線）~~ （管理者目線）

- ユーザのEmail検証が管理画面で行える様になる

## できなくなること ~~（ユーザ目線）~~ （管理者目線）

無し

## 動作確認

- 管理画面でユーザのEmail検証および検証の取り消しが出来る事を確認

## その他

無し