### PR TITLE
Github Notificationの実行トリガー・ブランチ変更

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,11 +1,9 @@
 name: Github Notification
 
 on:
-  pull_request:
+  push:
     branches:
       - develop
-      - main
-    types: [closed]
 
 jobs:
   slackNotification:


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- fork先からのプルリクエストに対しても通知が行くように（期待通り通知が行くかは不明）

## やったこと

- `Github Notification` の実行トリガーをプルリクエストのマージから，対象ブランチへのpushに変更
- 本番環境の通知が来ても混乱するとおもわれるので，対象ブランチから `main` を削除

## やらないこと

無し

## できるようになること ~~（ユーザ目線）~~ （開発者目線）

- `develop` ブランチへのマージ（push）時にslackへ通知が行く様になる（はず）

## できなくなること ~~（ユーザ目線）~~ （開発者目線）

無し

## 動作確認

無し

## その他

期待通り動作をしなければ，マージの取り消しを行います．