### PR TITLE
管理画面で取得出来る全てのhubリソースを取得し，その属性で検索が出来る様に変更

### DIFF
--- a/app/Filament/Resources/HubResource.php
+++ b/app/Filament/Resources/HubResource.php
@@ -74,13 +74,24 @@ class HubResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('thread_category.category_name')
-                    ->label('カテゴリ'),
+                    ->label('カテゴリ')
+                    ->searchable(isIndividual: true),
                 Tables\Columns\TextColumn::make('user.email')
-                    ->label('ユーザEmail'),
-                Tables\Columns\TextColumn::make('name'),
-                Tables\Columns\TextColumn::make('created_at'),
+                    ->label('ユーザEmail')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 Tables\Filters\TrashedFilter::make(),


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- （ほぼ）全ての属性を見る事が出来る様に
- 個々の目的のレコードを素早く発見出来る様にするため

## やったこと

- 取得出来る全ての属性を取得し，管理画面で表示
- 取得出来る全ての属性で検索が出来る様に変更

## やらないこと

無し

## できるようになること ~~（ユーザ目線）~~ （管理者目線）

- 管理画面のhubリソースで（ほぼ）全ての属性を確認することが出来る様になる
- 管理画面のhubリソースで確認出来る属性で検索が出来る様になる

## できなくなること ~~（ユーザ目線）~~ （管理者目線）

無し

## 動作確認

- 取得出来る全ての属性を取得し，管理画面で表示出来ている事を確認
- 取得出来る全ての属性で検索が出来る事を確認

## その他

無し