### PR TITLE
管理画面のusersリソースで全ての属性を閲覧・検索出来る様に変更

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -76,11 +76,27 @@ class UserResource extends Resource
     {
         return $table
             ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('user_page_theme.theme_name')
+                    ->label('ページテーマ'),
                 Tables\Columns\TextColumn::make('name'),
                 Tables\Columns\TextColumn::make('email'),
                 Tables\Columns\IconColumn::make('email_verified_at')
                     ->label('verified')
-                    ->boolean()
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('two_factor_confirmed_at')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('current_team_id')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('profile_photo_path')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 Tables\Filters\TrashedFilter::make(),

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\UserResource\Pages;
 use App\Filament\Resources\UserResource\RelationManagers;
 use App\Models\User;
+use App\Models\UserPageTheme;
 use Filament\Forms;
 use Filament\Resources\Forms\Components;
 use Filament\Resources\Form;
@@ -43,6 +44,11 @@ class UserResource extends Resource
     {
         return $form
             ->schema([
+                Forms\Components\Select::make('user_page_theme_id')
+                    ->label('ページテーマ')
+                    ->options(UserPageTheme::all()->pluck('theme_name', 'id'))
+                    ->searchable()
+                    ->default(1),
                 Forms\Components\TextInput::make('name')
                     ->required()
                     ->maxLength(255),

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -76,25 +76,36 @@ class UserResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('user_page_theme.theme_name')
-                    ->label('ページテーマ'),
-                Tables\Columns\TextColumn::make('name'),
-                Tables\Columns\TextColumn::make('email'),
+                    ->label('ページテーマ')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('email')
+                    ->searchable(isIndividual: true),
                 Tables\Columns\IconColumn::make('email_verified_at')
                     ->label('verified')
-                    ->boolean(),
+                    ->boolean()
+                    ->searchable(isIndividual: true),
                 Tables\Columns\TextColumn::make('two_factor_confirmed_at')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('current_team_id')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('profile_photo_path')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -35,7 +35,7 @@ class UserResource extends Resource
     /**
      * 管理画面で作成・編集する際のフォーム
      *
-     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     * @link https://filamentphp.com/docs/2.x/forms/fields
      *
      * @param Form $form
      * @return Form
@@ -66,8 +66,7 @@ class UserResource extends Resource
     /**
      * 管理画面での表示ページ
      *
-     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
-     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     * @link https://filamentphp.com/docs/2.x/admin/resources/listing-records
      *
      * @param Table $table
      * @return Table


### PR DESCRIPTION
## 関連

- #223 

## なぜこの変更をするのか

無し

## やったこと

- 管理画面のusersリソースの変更可能箇所を増やす．（fillableにある全ての属性）
- 管理画面のusersリソースでidを表示する（デフォルトでは「toggleable(isToggledHiddenByDefault: true)」を使用して非表示にする）
- 管理画面のusersリソースの参考リンクを変更する
- 管理画面のusersリソースで取得出来る全ての属性を取得
- 管理画面のusersリソースで取得出来た全ての属性で検索を可能にする

## やらないこと

無し

## できるようになること ~~（ユーザ目線）~~ （管理者目線）

- 管理画面のusersリソースでほぼ全ての属性を見られる様になる
- 管理画面のusersリソースでほぼ全ての属性でレコードを検索出来る様になる

## できなくなること ~~（ユーザ目線）~~ （管理者目線）

無し

## 動作確認

- 取得出来る全ての属性を取得し，管理画面で表示出来ている事を確認
- 取得出来る全ての属性で検索が出来る事を確認

## その他

無し