### PR TITLE
管理者による投稿の削除機能

### DIFF
--- a/app/Filament/Resources/ClubThreadResource.php
+++ b/app/Filament/Resources/ClubThreadResource.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ClubThreadResource\Pages;
+use App\Filament\Resources\ClubThreadResource\RelationManagers;
+use App\Models\ClubThread;
+use App\Models\Hub;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class ClubThreadResource extends Resource
+{
+    /**
+     * 対象のモデル
+     *
+     * @var string|null
+     */
+    protected static ?string $model = ClubThread::class;
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+
+    /**
+     * 管理画面で作成・編集する際のフォーム
+     *
+     * @link https://filamentphp.com/docs/2.x/forms/fields
+     *
+     * @param Form $form
+     * @return Form
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('hub_id')
+                    ->label('スレッドID')
+                    ->options(Hub::all()->pluck('id', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Select::make('user_id')
+                    ->label('ユーザEmail')
+                    ->options(User::all()->pluck('email', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\TextInput::make('message_id')
+                    ->numeric()
+                    ->minValue(1)
+                    ->required(),
+                Forms\Components\Textarea::make('message')
+                    ->required(),
+            ]);
+    }
+
+    /**
+     * 管理画面での表示ページ
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/resources/listing-records
+     *
+     * @param Table $table
+     * @return Table
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('hub.id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('user.email')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message_id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make()
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+                Tables\Actions\ForceDeleteBulkAction::make(),
+                Tables\Actions\RestoreBulkAction::make(),
+            ]);
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/relation-managers
+     *
+     * @return array
+     */
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return array
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListClubThreads::route('/'),
+            'create' => Pages\CreateClubThread::route('/create'),
+            'view' => Pages\ViewClubThread::route('/{record}'),
+            'edit' => Pages\EditClubThread::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return Builder
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/ClubThreadResource.php
+++ b/app/Filament/Resources/ClubThreadResource.php
@@ -32,6 +32,15 @@ class ClubThreadResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-collection';
 
     /**
+     * 項目のグループ化
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/navigation#grouping-navigation-items
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationGroup = 'Posts';
+
+    /**
      * 管理画面で作成・編集する際のフォーム
      *
      * @link https://filamentphp.com/docs/2.x/forms/fields

--- a/app/Filament/Resources/ClubThreadResource/Pages/CreateClubThread.php
+++ b/app/Filament/Resources/ClubThreadResource/Pages/CreateClubThread.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\ClubThreadResource\Pages;
+
+use App\Filament\Resources\ClubThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateClubThread extends CreateRecord
+{
+    protected static string $resource = ClubThreadResource::class;
+}

--- a/app/Filament/Resources/ClubThreadResource/Pages/EditClubThread.php
+++ b/app/Filament/Resources/ClubThreadResource/Pages/EditClubThread.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\ClubThreadResource\Pages;
+
+use App\Filament\Resources\ClubThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditClubThread extends EditRecord
+{
+    protected static string $resource = ClubThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ClubThreadResource/Pages/ListClubThreads.php
+++ b/app/Filament/Resources/ClubThreadResource/Pages/ListClubThreads.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ClubThreadResource\Pages;
+
+use App\Filament\Resources\ClubThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListClubThreads extends ListRecords
+{
+    protected static string $resource = ClubThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ClubThreadResource/Pages/ViewClubThread.php
+++ b/app/Filament/Resources/ClubThreadResource/Pages/ViewClubThread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ClubThreadResource\Pages;
+
+use App\Filament\Resources\ClubThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewClubThread extends ViewRecord
+{
+    protected static string $resource = ClubThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CollegeYearThreadResource.php
+++ b/app/Filament/Resources/CollegeYearThreadResource.php
@@ -32,6 +32,15 @@ class CollegeYearThreadResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-collection';
 
     /**
+     * 項目のグループ化
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/navigation#grouping-navigation-items
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationGroup = 'Posts';
+
+    /**
      * 管理画面で作成・編集する際のフォーム
      *
      * @link https://filamentphp.com/docs/2.x/forms/fields

--- a/app/Filament/Resources/CollegeYearThreadResource.php
+++ b/app/Filament/Resources/CollegeYearThreadResource.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\CollegeYearThreadResource\Pages;
+use App\Filament\Resources\CollegeYearThreadResource\RelationManagers;
+use App\Models\CollegeYearThread;
+use App\Models\Hub;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class CollegeYearThreadResource extends Resource
+{
+    /**
+     * 対象のモデル
+     *
+     * @var string|null
+     */
+    protected static ?string $model = CollegeYearThread::class;
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+
+    /**
+     * 管理画面で作成・編集する際のフォーム
+     *
+     * @link https://filamentphp.com/docs/2.x/forms/fields
+     *
+     * @param Form $form
+     * @return Form
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('hub_id')
+                    ->label('スレッドID')
+                    ->options(Hub::all()->pluck('id', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Select::make('user_id')
+                    ->label('ユーザEmail')
+                    ->options(User::all()->pluck('email', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\TextInput::make('message_id')
+                    ->numeric()
+                    ->minValue(1)
+                    ->required(),
+                Forms\Components\Textarea::make('message')
+                    ->required(),
+            ]);
+    }
+
+    /**
+     * 管理画面での表示ページ
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/resources/listing-records
+     *
+     * @param Table $table
+     * @return Table
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('hub.id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('user.email')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message_id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make()
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+                Tables\Actions\ForceDeleteBulkAction::make(),
+                Tables\Actions\RestoreBulkAction::make(),
+            ]);
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/relation-managers
+     *
+     * @return array
+     */
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return array
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCollegeYearThreads::route('/'),
+            'create' => Pages\CreateCollegeYearThread::route('/create'),
+            'view' => Pages\ViewCollegeYearThread::route('/{record}'),
+            'edit' => Pages\EditCollegeYearThread::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return Builder
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/CollegeYearThreadResource/Pages/CreateCollegeYearThread.php
+++ b/app/Filament/Resources/CollegeYearThreadResource/Pages/CreateCollegeYearThread.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\CollegeYearThreadResource\Pages;
+
+use App\Filament\Resources\CollegeYearThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCollegeYearThread extends CreateRecord
+{
+    protected static string $resource = CollegeYearThreadResource::class;
+}

--- a/app/Filament/Resources/CollegeYearThreadResource/Pages/EditCollegeYearThread.php
+++ b/app/Filament/Resources/CollegeYearThreadResource/Pages/EditCollegeYearThread.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\CollegeYearThreadResource\Pages;
+
+use App\Filament\Resources\CollegeYearThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCollegeYearThread extends EditRecord
+{
+    protected static string $resource = CollegeYearThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CollegeYearThreadResource/Pages/ListCollegeYearThreads.php
+++ b/app/Filament/Resources/CollegeYearThreadResource/Pages/ListCollegeYearThreads.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CollegeYearThreadResource\Pages;
+
+use App\Filament\Resources\CollegeYearThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCollegeYearThreads extends ListRecords
+{
+    protected static string $resource = CollegeYearThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CollegeYearThreadResource/Pages/ViewCollegeYearThread.php
+++ b/app/Filament/Resources/CollegeYearThreadResource/Pages/ViewCollegeYearThread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CollegeYearThreadResource\Pages;
+
+use App\Filament\Resources\CollegeYearThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewCollegeYearThread extends ViewRecord
+{
+    protected static string $resource = CollegeYearThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DepartmentThreadResource.php
+++ b/app/Filament/Resources/DepartmentThreadResource.php
@@ -32,6 +32,15 @@ class DepartmentThreadResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-collection';
 
     /**
+     * 項目のグループ化
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/navigation#grouping-navigation-items
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationGroup = 'Posts';
+
+    /**
      * 管理画面で作成・編集する際のフォーム
      *
      * @link https://filamentphp.com/docs/2.x/forms/fields

--- a/app/Filament/Resources/DepartmentThreadResource.php
+++ b/app/Filament/Resources/DepartmentThreadResource.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DepartmentThreadResource\Pages;
+use App\Filament\Resources\DepartmentThreadResource\RelationManagers;
+use App\Models\DepartmentThread;
+use App\Models\Hub;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class DepartmentThreadResource extends Resource
+{
+    /**
+     * 対象のモデル
+     *
+     * @var string|null
+     */
+    protected static ?string $model = DepartmentThread::class;
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+
+    /**
+     * 管理画面で作成・編集する際のフォーム
+     *
+     * @link https://filamentphp.com/docs/2.x/forms/fields
+     *
+     * @param Form $form
+     * @return Form
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('hub_id')
+                    ->label('スレッドID')
+                    ->options(Hub::all()->pluck('id', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Select::make('user_id')
+                    ->label('ユーザEmail')
+                    ->options(User::all()->pluck('email', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\TextInput::make('message_id')
+                    ->numeric()
+                    ->minValue(1)
+                    ->required(),
+                Forms\Components\Textarea::make('message')
+                    ->required(),
+            ]);
+    }
+
+    /**
+     * 管理画面での表示ページ
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/resources/listing-records
+     *
+     * @param Table $table
+     * @return Table
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('hub.id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('user.email')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message_id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make()
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+                Tables\Actions\ForceDeleteBulkAction::make(),
+                Tables\Actions\RestoreBulkAction::make(),
+            ]);
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/relation-managers
+     *
+     * @return array
+     */
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return array
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDepartmentThreads::route('/'),
+            'create' => Pages\CreateDepartmentThread::route('/create'),
+            'view' => Pages\ViewDepartmentThread::route('/{record}'),
+            'edit' => Pages\EditDepartmentThread::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return Builder
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/DepartmentThreadResource/Pages/CreateDepartmentThread.php
+++ b/app/Filament/Resources/DepartmentThreadResource/Pages/CreateDepartmentThread.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\DepartmentThreadResource\Pages;
+
+use App\Filament\Resources\DepartmentThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDepartmentThread extends CreateRecord
+{
+    protected static string $resource = DepartmentThreadResource::class;
+}

--- a/app/Filament/Resources/DepartmentThreadResource/Pages/EditDepartmentThread.php
+++ b/app/Filament/Resources/DepartmentThreadResource/Pages/EditDepartmentThread.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\DepartmentThreadResource\Pages;
+
+use App\Filament\Resources\DepartmentThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDepartmentThread extends EditRecord
+{
+    protected static string $resource = DepartmentThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DepartmentThreadResource/Pages/ListDepartmentThreads.php
+++ b/app/Filament/Resources/DepartmentThreadResource/Pages/ListDepartmentThreads.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DepartmentThreadResource\Pages;
+
+use App\Filament\Resources\DepartmentThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDepartmentThreads extends ListRecords
+{
+    protected static string $resource = DepartmentThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DepartmentThreadResource/Pages/ViewDepartmentThread.php
+++ b/app/Filament/Resources/DepartmentThreadResource/Pages/ViewDepartmentThread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DepartmentThreadResource\Pages;
+
+use App\Filament\Resources\DepartmentThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDepartmentThread extends ViewRecord
+{
+    protected static string $resource = DepartmentThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/JobHuntingThreadResource.php
+++ b/app/Filament/Resources/JobHuntingThreadResource.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\JobHuntingThreadResource\Pages;
+use App\Filament\Resources\JobHuntingThreadResource\RelationManagers;
+use App\Models\Hub;
+use App\Models\JobHuntingThread;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class JobHuntingThreadResource extends Resource
+{
+    /**
+     * 対象のモデル
+     *
+     * @var string|null
+     */
+    protected static ?string $model = JobHuntingThread::class;
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+
+    /**
+     * 管理画面で作成・編集する際のフォーム
+     *
+     * @link https://filamentphp.com/docs/2.x/forms/fields
+     *
+     * @param Form $form
+     * @return Form
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('hub_id')
+                    ->label('スレッドID')
+                    ->options(Hub::all()->pluck('id', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Select::make('user_id')
+                    ->label('ユーザEmail')
+                    ->options(User::all()->pluck('email', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\TextInput::make('message_id')
+                    ->numeric()
+                    ->minValue(1)
+                    ->required(),
+                Forms\Components\Textarea::make('message')
+                    ->required(),
+            ]);
+    }
+
+    /**
+     * 管理画面での表示ページ
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/resources/listing-records
+     *
+     * @param Table $table
+     * @return Table
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('hub.id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('user.email')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message_id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make()
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+                Tables\Actions\ForceDeleteBulkAction::make(),
+                Tables\Actions\RestoreBulkAction::make(),
+            ]);
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/relation-managers
+     *
+     * @return array
+     */
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return array
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListJobHuntingThreads::route('/'),
+            'create' => Pages\CreateJobHuntingThread::route('/create'),
+            'view' => Pages\ViewJobHuntingThread::route('/{record}'),
+            'edit' => Pages\EditJobHuntingThread::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return Builder
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/JobHuntingThreadResource.php
+++ b/app/Filament/Resources/JobHuntingThreadResource.php
@@ -32,6 +32,15 @@ class JobHuntingThreadResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-collection';
 
     /**
+     * 項目のグループ化
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/navigation#grouping-navigation-items
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationGroup = 'Posts';
+
+    /**
      * 管理画面で作成・編集する際のフォーム
      *
      * @link https://filamentphp.com/docs/2.x/forms/fields

--- a/app/Filament/Resources/JobHuntingThreadResource/Pages/CreateJobHuntingThread.php
+++ b/app/Filament/Resources/JobHuntingThreadResource/Pages/CreateJobHuntingThread.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\JobHuntingThreadResource\Pages;
+
+use App\Filament\Resources\JobHuntingThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateJobHuntingThread extends CreateRecord
+{
+    protected static string $resource = JobHuntingThreadResource::class;
+}

--- a/app/Filament/Resources/JobHuntingThreadResource/Pages/EditJobHuntingThread.php
+++ b/app/Filament/Resources/JobHuntingThreadResource/Pages/EditJobHuntingThread.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\JobHuntingThreadResource\Pages;
+
+use App\Filament\Resources\JobHuntingThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditJobHuntingThread extends EditRecord
+{
+    protected static string $resource = JobHuntingThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/JobHuntingThreadResource/Pages/ListJobHuntingThreads.php
+++ b/app/Filament/Resources/JobHuntingThreadResource/Pages/ListJobHuntingThreads.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\JobHuntingThreadResource\Pages;
+
+use App\Filament\Resources\JobHuntingThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListJobHuntingThreads extends ListRecords
+{
+    protected static string $resource = JobHuntingThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/JobHuntingThreadResource/Pages/ViewJobHuntingThread.php
+++ b/app/Filament/Resources/JobHuntingThreadResource/Pages/ViewJobHuntingThread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\JobHuntingThreadResource\Pages;
+
+use App\Filament\Resources\JobHuntingThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewJobHuntingThread extends ViewRecord
+{
+    protected static string $resource = JobHuntingThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/LectureThreadResource.php
+++ b/app/Filament/Resources/LectureThreadResource.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\LectureThreadResource\Pages;
+use App\Filament\Resources\LectureThreadResource\RelationManagers;
+use App\Models\Hub;
+use App\Models\LectureThread;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class LectureThreadResource extends Resource
+{
+    /**
+     * 対象のモデル
+     *
+     * @var string|null
+     */
+    protected static ?string $model = LectureThread::class;
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+
+    /**
+     * 管理画面で作成・編集する際のフォーム
+     *
+     * @link https://filamentphp.com/docs/2.x/forms/fields
+     *
+     * @param Form $form
+     * @return Form
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('hub_id')
+                    ->label('スレッドID')
+                    ->options(Hub::all()->pluck('id', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Select::make('user_id')
+                    ->label('ユーザEmail')
+                    ->options(User::all()->pluck('email', 'id'))
+                    ->searchable()
+                    ->required(),
+                Forms\Components\TextInput::make('message_id')
+                    ->numeric()
+                    ->minValue(1)
+                    ->required(),
+                Forms\Components\Textarea::make('message')
+                    ->required(),
+            ]);
+    }
+
+    /**
+     * 管理画面での表示ページ
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/resources/listing-records
+     *
+     * @param Table $table
+     * @return Table
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('hub.id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('user.email')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message_id')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('message')
+                    ->searchable(isIndividual: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->searchable(isIndividual: true)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make()
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+                Tables\Actions\ForceDeleteBulkAction::make(),
+                Tables\Actions\RestoreBulkAction::make(),
+            ]);
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/relation-managers
+     *
+     * @return array
+     */
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return array
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListLectureThreads::route('/'),
+            'create' => Pages\CreateLectureThread::route('/create'),
+            'view' => Pages\ViewLectureThread::route('/{record}'),
+            'edit' => Pages\EditLectureThread::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @link https://filamentphp.com/docs/2.x/admin/resources/getting-started
+     *
+     * @return Builder
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/LectureThreadResource.php
+++ b/app/Filament/Resources/LectureThreadResource.php
@@ -32,6 +32,15 @@ class LectureThreadResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-collection';
 
     /**
+     * 項目のグループ化
+     *
+     * @link https://filamentphp.com/docs/2.x/admin/navigation#grouping-navigation-items
+     *
+     * @var string|null
+     */
+    protected static ?string $navigationGroup = 'Posts';
+
+    /**
      * 管理画面で作成・編集する際のフォーム
      *
      * @link https://filamentphp.com/docs/2.x/forms/fields

--- a/app/Filament/Resources/LectureThreadResource/Pages/CreateLectureThread.php
+++ b/app/Filament/Resources/LectureThreadResource/Pages/CreateLectureThread.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\LectureThreadResource\Pages;
+
+use App\Filament\Resources\LectureThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateLectureThread extends CreateRecord
+{
+    protected static string $resource = LectureThreadResource::class;
+}

--- a/app/Filament/Resources/LectureThreadResource/Pages/EditLectureThread.php
+++ b/app/Filament/Resources/LectureThreadResource/Pages/EditLectureThread.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\LectureThreadResource\Pages;
+
+use App\Filament\Resources\LectureThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditLectureThread extends EditRecord
+{
+    protected static string $resource = LectureThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/LectureThreadResource/Pages/ListLectureThreads.php
+++ b/app/Filament/Resources/LectureThreadResource/Pages/ListLectureThreads.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\LectureThreadResource\Pages;
+
+use App\Filament\Resources\LectureThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListLectureThreads extends ListRecords
+{
+    protected static string $resource = LectureThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/LectureThreadResource/Pages/ViewLectureThread.php
+++ b/app/Filament/Resources/LectureThreadResource/Pages/ViewLectureThread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\LectureThreadResource\Pages;
+
+use App\Filament\Resources\LectureThreadResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewLectureThread extends ViewRecord
+{
+    protected static string $resource = LectureThreadResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ClubThread extends Model
 {
     use HasFactory;
     use SerializeDate;
+    use SoftDeletes;
 
     /**
      * 接続するデータベース
@@ -70,6 +72,7 @@ class ClubThread extends Model
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
+        'deleted_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class CollegeYearThread extends Model
 {
     use HasFactory;
     use SerializeDate;
+    use SoftDeletes;
 
     /**
      * 接続するデータベース
@@ -70,6 +72,7 @@ class CollegeYearThread extends Model
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
+        'deleted_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DepartmentThread extends Model
 {
     use HasFactory;
     use SerializeDate;
+    use SoftDeletes;
 
     /**
      * 接続するデータベース
@@ -70,6 +72,7 @@ class DepartmentThread extends Model
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
+        'deleted_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class JobHuntingThread extends Model
 {
     use HasFactory;
     use SerializeDate;
+    use SoftDeletes;
 
     /**
      * 接続するデータベース
@@ -70,6 +72,7 @@ class JobHuntingThread extends Model
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
+        'deleted_at' => 'datetime:Y-m-d H:i:s',
     ];
 
 

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class LectureThread extends Model
 {
     use HasFactory;
     use SerializeDate;
+    use SoftDeletes;
 
     /**
      * 接続するデータベース
@@ -70,6 +72,7 @@ class LectureThread extends Model
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
         'update_at' => 'datetime:Y-m-d H:i:s',
+        'deleted_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/database/migrations/2022_12_14_233235_add_column_deleted_at_to_threads_table.php
+++ b/database/migrations/2022_12_14_233235_add_column_deleted_at_to_threads_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * `php artisan migrate` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * `php artisan migrate:rollback` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_threads', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+
+        Schema::table('college_year_threads', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+
+        Schema::table('department_threads', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+
+        Schema::table('job_hunting_threads', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+
+        Schema::table('lecture_threads', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};


### PR DESCRIPTION
## 関連

- #166 

## なぜこの変更をするのか

なし

## やったこと

- `club_threads`，`college_year_threads`，`department_threads`，`job_hunting_threads`，`lecture_threads` のテーブルで論理削除を有効に
- 管理画面に `club_threads`，`college_year_threads`，`department_threads`，`job_hunting_threads`，`lecture_threads` リソースを追加
- 管理画面の `club_threads`，`college_year_threads`，`department_threads`，`job_hunting_threads`，`lecture_threads` リソースをグループ化

## やらないこと

なし

## できるようになること ~~（ユーザ目線）~~ （管理者目線）

- スレッドへの書き込みを削除・復元できるようになる

## できなくなること ~~（ユーザ目線）~~ （管理者目線）

なし

## 動作確認

- すべての大枠カテゴリにおいて，書き込みの削除・復元ができることを確認
- すべての大枠カテゴリにおいて，削除された書き込みが表示されないことを確認

## その他

削除された書き込みに「この書き込みは削除されました」の表示をしてもいいかもしれません