### PR TITLE
キャストするカラム名が間違っていたため修正

### DIFF
--- a/app/Models/AccessLog.php
+++ b/app/Models/AccessLog.php
@@ -54,7 +54,7 @@ class AccessLog extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -69,7 +69,7 @@ class ClubThread extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -69,7 +69,7 @@ class CollegeYearThread extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/ContactAdministrator.php
+++ b/app/Models/ContactAdministrator.php
@@ -67,7 +67,7 @@ class ContactAdministrator extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -69,7 +69,7 @@ class DepartmentThread extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/Hub.php
+++ b/app/Models/Hub.php
@@ -54,7 +54,7 @@ class Hub extends UuidModel
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
         'deleted_at' => 'datetime:Y-m-d H:i:s',
     ];
 

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -69,7 +69,7 @@ class JobHuntingThread extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
 

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -69,7 +69,7 @@ class LectureThread extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -71,7 +71,7 @@ class Like extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/ThreadCategory.php
+++ b/app/Models/ThreadCategory.php
@@ -52,7 +52,7 @@ class ThreadCategory extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/ThreadImagePath.php
+++ b/app/Models/ThreadImagePath.php
@@ -58,7 +58,7 @@ class ThreadImagePath extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -90,7 +90,7 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
     protected $casts = [
         'email_verified_at' => 'datetime:Y-m-d H:i:s',
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
         'deleted_at' => 'datetime:Y-m-d H:i:s'
     ];
 

--- a/app/Models/UserPageTheme.php
+++ b/app/Models/UserPageTheme.php
@@ -51,7 +51,7 @@ class UserPageTheme extends Model
      */
     protected $casts = [
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
+        'updated_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- モデルでキャストするカラム名が異なっていたため修正

## やったこと

- モデルでキャストするカラムとして `update_at` となっていたものを `updated_at` へ変更 

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

なし

## その他

なし