### PR TITLE
スレッドにwebp形式の画像をアップロード可能にする

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -18,6 +18,7 @@ RUN \
         libfreetype6-dev \
         libjpeg-dev \
         libpng-dev \
+        libwebp-dev \
         libzip-dev \
         zlib1g-dev \
     ; \
@@ -28,7 +29,10 @@ RUN \
 	rm -rf /var/lib/apt/lists/* \
     ; \
     # # Install Required PHP extensions
-	docker-php-ext-configure gd --with-freetype --with-jpeg; \
+	docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp; \
 	docker-php-ext-install \
 		bcmath \
 		exif \


### PR DESCRIPTION
## 関連

- #232 
- #233 

## なぜこの変更をするのか

なし

## やったこと

- webp形式の画像を扱えるようにDockerfileを編集
- webp形式の画像をアップロードしたときのテストを修正

## やらないこと

- 扱えない形式の画像をアップロードされたときの処理を追加すること

## できるようになること（ユーザ目線）

- webp形式の画像をアップロードできるようになる

## できなくなること（ユーザ目線）

なし

## 動作確認

- webp形式の画像をアップロードできることを確認

## その他

なし