### PR TITLE
アクセスログをスレッドアクセスした際だけに保存するように変更

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -17,7 +17,6 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
-        \App\Http\Middleware\AccessLog::class,
         \App\Http\Middleware\TrustProxies::class,
         \Fruitcake\Cors\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
@@ -61,6 +60,7 @@ class Kernel extends HttpKernel
      * @var array<string, class-string|string>
      */
     protected $routeMiddleware = [
+        'access_log' => \App\Http\Middleware\AccessLog::class,
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,

--- a/app/Http/Middleware/AccessLog.php
+++ b/app/Http/Middleware/AccessLog.php
@@ -27,10 +27,15 @@ class AccessLog
     public function handle(Request $request, Closure $next)
     {
         $response = $next($request);
-        Log::create([
-            'hub_id' => $request->thread_id,
-            'user_id' => $request->user()->id ?? null,
-        ]);
+
+        if (session()->get('thread_id') !== $request->thread_id) {
+            Log::create([
+                'hub_id' => $request->thread_id,
+                'user_id' => $request->user()->id ?? null,
+            ]);
+        }
+        session()->put('thread_id', $request->thread_id);
+
         return $response;
     }
 }

--- a/app/Http/Middleware/AccessLog.php
+++ b/app/Http/Middleware/AccessLog.php
@@ -27,29 +27,10 @@ class AccessLog
     public function handle(Request $request, Closure $next)
     {
         $response = $next($request);
-
-        if (strcmp(url()->current(), route('thread.get')) !== 0) {
-            $thread_id = $request->thread_id;
-            if (strpos($request->path(), 'jQuery.ajax') === 0) {
-                $thread_id = null;
-            }
-
-            try {
-                Log::create([
-                    'hub_id' => $thread_id,
-                    'session_id' => $request->session()->getId(),
-                    'user_id' => $request->user()->id ?? null,
-                    'uri' => $request->path(),
-                ]);
-            } catch (RuntimeException) {
-                /*
-                RuntimeException: Session store not set on request.
-
-                実際にはSessionの取得が出来ているため，例外が発生した場合は何もしない
-                */
-            }
-        }
-
+        Log::create([
+            'hub_id' => $request->thread_id,
+            'user_id' => $request->user()->id ?? null,
+        ]);
         return $response;
     }
 }

--- a/app/Http/Middleware/AccessLog.php
+++ b/app/Http/Middleware/AccessLog.php
@@ -28,13 +28,17 @@ class AccessLog
     {
         $response = $next($request);
 
-        if (session()->get('thread_id') !== $request->thread_id) {
-            Log::create([
-                'hub_id' => $request->thread_id,
-                'user_id' => $request->user()->id ?? null,
-            ]);
+        if (Hub::where('id', '=', $request->thread_id)->first()->id ?? null === $request->thread_id) {
+            if (session()->get('thread_id') !== $request->thread_id) {
+                Log::create([
+                    'hub_id' => $request->thread_id,
+                    'user_id' => $request->user()->id ?? null,
+                ]);
+                session()->put('thread_id', $request->thread_id);
+            }
+        } else {
+            abort(404);
         }
-        session()->put('thread_id', $request->thread_id);
 
         return $response;
     }

--- a/app/Models/AccessLog.php
+++ b/app/Models/AccessLog.php
@@ -40,9 +40,7 @@ class AccessLog extends Model
      */
     protected $fillable = [
         'hub_id',
-        'session_id',
         'user_id',
-        'uri',
     ];
 
     /**

--- a/database/migrations/2022_12_31_212013_drop_column_session_id_to_access_logs_table.php
+++ b/database/migrations/2022_12_31_212013_drop_column_session_id_to_access_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('access_logs', function (Blueprint $table) {
+            $table->dropColumn('session_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('access_logs', function (Blueprint $table) {
+            $table->string('session_id');
+        });
+    }
+};

--- a/database/migrations/2022_12_31_212036_drop_column_uri_to_access_logs_table.php
+++ b/database/migrations/2022_12_31_212036_drop_column_uri_to_access_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('access_logs', function (Blueprint $table) {
+            $table->dropColumn('uri');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('access_logs', function (Blueprint $table) {
+            $table->text('uri');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,10 +33,14 @@ Route::middleware([
     Route::get('dashboard', 'App\Http\Controllers\Dashboard\DashboardController@threads')->name('dashboard');
     Route::get('Q_and_A', 'App\Http\Controllers\QandA\QandAController@Q_and_A')->name('Q_and_A');
 
-    Route::get('dashboard/thread/name={thread_name}&id={thread_id}', 'App\Http\Controllers\Dashboard\DashboardController@messages');
-    Route::get('dashboard/thread/name={thread_name}&id=', 'App\Http\Controllers\Dashboard\DashboardController@messages');
-    Route::get('dashboard/thread/name=&id={thread_id}', 'App\Http\Controllers\Dashboard\DashboardController@messages');
-    Route::get('dashboard/thread/name=&id=', 'App\Http\Controllers\Dashboard\DashboardController@messages');
+    Route::middleware([
+        'access_log'
+    ])->group(function () {
+        Route::get('dashboard/thread/name={thread_name}&id={thread_id}', 'App\Http\Controllers\Dashboard\DashboardController@messages');
+        Route::get('dashboard/thread/name={thread_name}&id=', 'App\Http\Controllers\Dashboard\DashboardController@messages');
+        Route::get('dashboard/thread/name=&id={thread_id}', 'App\Http\Controllers\Dashboard\DashboardController@messages');
+        Route::get('dashboard/thread/name=&id=', 'App\Http\Controllers\Dashboard\DashboardController@messages');
+    });
 });
 
 // 画面遷移：ログインが必要

--- a/tests/Feature/Dashboard/AuthenticationTest.php
+++ b/tests/Feature/Dashboard/AuthenticationTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Tests\Feature\dashboard;
+namespace Tests\Feature\Dashboard;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase

--- a/tests/Feature/Dashboard/Thread/AccessLogTest.php
+++ b/tests/Feature/Dashboard/Thread/AccessLogTest.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace Tests\Feature\Dashboard\Thread;
+
+use App\Models\AccessLog;
+use App\Models\Hub;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AccessLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * テスト用ユーザ
+     *
+     * @var User
+     */
+    private User $user;
+
+    /**
+     * テスト用スレッド
+     *
+     * @var Hub
+     */
+    private Hub $thread_id;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->thread = Hub::factory()->create();
+    }
+
+    /**
+     * アクセスログ保存後に，access_logs テーブルに保存されているデータ（key）の期待値を返却する
+     *
+     * @return array
+     */
+    private function getKeysExpected(): array
+    {
+        return [
+            'id',
+            'hub_id',
+            'user_id',
+            'created_at',
+            'updated_at',
+        ];
+    }
+
+    /**
+     * アクセスログ保存後に，access_logs テーブルに保存されているデータ（value）の期待値を返却する
+     *
+     * @param string|null $thread_idn
+     * @param User|null $user
+     * @return array
+     */
+    private function getValuesExpected(string $thread_id = null, User $user = null): array
+    {
+        $user_id = null;
+        if ($user !== null) {
+            $user_id = $user->id . '';
+        }
+
+        return [
+            'hub_id' => $thread_id ?? $this->thread->id . '',
+            'user_id' => $user_id,
+        ];
+    }
+
+    /**
+     * 渡された配列のうち，指定したインデックスの要素を返却する
+     *
+     * @param array $ary 連想配列
+     * @param array $keys 連想配列のインデックスを指定
+     * @return array インデックスと一致した連想配列を返却
+     */
+    private function getArrayElement(array $ary, array $keys): array
+    {
+        $response = [];
+        foreach ($keys as $key) {
+            $response[$key] = $ary[$key];
+        }
+        return $response;
+    }
+
+    /**
+     * ログインしていない状態でスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_threads_without_being_logged_in(): void
+    {
+        $this->assertSame(session()->get('thread_id'), null);
+        $response = $this->get('/dashboard/thread/name=' . $this->thread->name . '&id=' . $this->thread->id);
+        $response->assertOk();
+        $this->assertSame(session()->get('thread_id'), $this->thread->id . '');
+
+        $access_log = AccessLog::where('hub_id', '=', $this->thread->id)->first()->toArray();
+        $access_logs_count = AccessLog::where('hub_id', '=', $this->thread->id)->count();
+
+        $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+        $this->assertSame(
+            $this->getValuesExpected(),
+            $this->getArrayElement($access_log, [
+                'hub_id',
+                'user_id',
+            ])
+        );
+        $this->assertSame(1, $access_logs_count);
+    }
+
+    /**
+     * ログインしている状態でスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_threads_while_logged_in(): void
+    {
+        $this->assertSame(session()->get('thread_id'), null);
+        $response = $this->actingAs($this->user)
+            ->get('/dashboard/thread/name=' . $this->thread->name . '&id=' . $this->thread->id);
+        $response->assertOk();
+        $this->assertSame(session()->get('thread_id'), $this->thread->id . '');
+
+        $access_log = AccessLog::where('hub_id', '=', $this->thread->id)
+            ->where('user_id', '=', $this->user->id)
+            ->first()
+            ->toArray();
+        $access_logs_count = AccessLog::where('hub_id', '=', $this->thread->id)
+            ->where('user_id', '=', $this->user->id)
+            ->count();
+
+        $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+        $this->assertSame(
+            $this->getValuesExpected(user: $this->user),
+            $this->getArrayElement($access_log, [
+                'hub_id',
+                'user_id',
+            ])
+        );
+        $this->assertSame(1, $access_logs_count);
+    }
+
+    /**
+     * ログインしていない状態で同じスレッドに複数回アクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_the_same_thread_multiple_times_without_being_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $this->thread->id . '');
+            }
+            $response = $this->get('/dashboard/thread/name=' . $this->thread->name . '&id=' . $this->thread->id);
+            $response->assertOk();
+            $this->assertSame(session()->get('thread_id'), $this->thread->id . '');
+
+            $access_log = AccessLog::where('hub_id', '=', $this->thread->id)->first()->toArray();
+            $access_logs_count = AccessLog::where('hub_id', '=', $this->thread->id)->count();
+
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * ログインしている状態で同じスレッドに複数回アクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_the_same_thread_multiple_times_while_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $this->thread->id . '');
+            }
+            $response = $this->actingAs($this->user)
+                ->get('/dashboard/thread/name=' . $this->thread->name . '&id=' . $this->thread->id);
+            $response->assertOk();
+            $this->assertSame(session()->get('thread_id'), $this->thread->id . '');
+
+            $access_log = AccessLog::where('hub_id', '=', $this->thread->id)
+                ->where('user_id', '=', $this->user->id)
+                ->first()
+                ->toArray();
+            $access_logs_count = AccessLog::where('hub_id', '=', $this->thread->id)
+                ->where('user_id', '=', $this->user->id)
+                ->count();
+
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(user: $this->user),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * ログインしていない状態で存在しないスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_non_existent_threads_without_being_logged_in(): void
+    {
+        $thread_name = 'non existent thread id';
+        $thread_id = 'non existent thread id';
+
+        $this->assertSame(session()->get('thread_id'), null);
+        $response = $this->get('/dashboard/thread/name=' . $thread_name . '&id=' . $thread_id);
+        $response->assertNotFound();
+        $this->assertSame(session()->get('thread_id'), null);
+
+        $access_log = AccessLog::where('hub_id', '=', $this->thread->id)->get()->toArray();
+        $access_logs_count = AccessLog::where('hub_id', '=', $this->thread->id)->count();
+
+        $this->assertSame([], $access_log);
+        $this->assertSame(0, $access_logs_count);
+    }
+
+    /**
+     * ログインしている状態で存在しないスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_a_thread_that_does_not_exist_while_logged_in(): void
+    {
+        $thread_name = 'non existent thread id';
+        $thread_id = 'non existent thread id';
+
+        $this->assertSame(session()->get('thread_id'), null);
+        $response = $this
+            ->actingAs($this->user)
+            ->get('/dashboard/thread/name=' . $thread_name . '&id=' . $thread_id);
+        $response->assertNotFound();
+        $this->assertSame(session()->get('thread_id'), null);
+
+        $access_log = AccessLog::where('hub_id', '=', $this->thread->id)
+            ->where('user_id', '=', $this->user->id)
+            ->get()
+            ->toArray();
+        $access_logs_count = AccessLog::where('hub_id', '=', $this->thread->id)
+            ->where('user_id', '=', $this->user->id)
+            ->count();
+
+        $this->assertSame([], $access_log);
+        $this->assertSame(0, $access_logs_count);
+    }
+
+    /**
+     * ログインしていない状態で複数のスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_multiple_threads_without_being_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            $pre_thread = $thread ?? null;
+            $thread = Hub::factory()->create();
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $pre_thread->id . '');
+            }
+            $response = $this->get('/dashboard/thread/name=' . $thread->name . '&id=' . $thread->id);
+            $response->assertOk();
+            $this->assertSame(session()->get('thread_id'), $thread->id . '');
+
+            $access_log = AccessLog::where('hub_id', '=', $thread->id)->first()->toArray();
+            $access_logs_count = AccessLog::where('hub_id', '=', $thread->id)->count();
+
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(thread_id: $thread->id),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * ログインしている状態で複数のスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_access_multiple_threads_while_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            $pre_thread = $thread ?? null;
+            $thread = Hub::factory()->create();
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $pre_thread->id . '');
+            }
+            $response = $this->actingAs($this->user)
+                ->get('/dashboard/thread/name=' . $thread->name . '&id=' . $thread->id);
+            $response->assertOk();
+            $this->assertSame(session()->get('thread_id'), $thread->id . '');
+
+            $access_log = AccessLog::where('hub_id', '=', $thread->id)
+                ->where('user_id', '=', $this->user->id)->first()->toArray();
+            $access_logs_count = AccessLog::where('hub_id', '=', $thread->id)
+                ->where('user_id', '=', $this->user->id)->count();
+
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(thread_id: $thread->id, user: $this->user),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * スレッド以外へアクセスした際にアクセスログが保存されないことを確認
+     *
+     * すべてのルートを網羅している訳ではありません
+     *
+     * @todo すべてのルートを網羅する
+     *
+     * @return void
+     */
+    public function test_confirmation_that_access_logs_are_not_saved_when_accessing_non_threads(): void
+    {
+        $pre_access_logs_count = AccessLog::count();
+        $this->get('/');
+        $this->get(route('dashboard'));
+        $this->get(route('Q_and_A'));
+        $this->get(route('mypage'));
+        $this->get(route('profile.show'));
+        $this->get(route('report.create'));
+        $this->get(route('login'));
+        $this->get(route('register'));
+        $access_logs_count = AccessLog::count();
+        $this->assertSame($pre_access_logs_count, $access_logs_count);
+    }
+}

--- a/tests/Unit/app/Http/Middleware/AccessLog/HandleTest.php
+++ b/tests/Unit/app/Http/Middleware/AccessLog/HandleTest.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace Tests\Unit\app\Http\Middleware\AccessLog;
+
+use App\Http\Middleware\AccessLog;
+use App\Models\AccessLog as AccessLogs;
+use App\Models\Hub;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class HandleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Hub $thread_id;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->thread = Hub::factory()->create();
+    }
+
+    /**
+     * アクセスログ保存後に，access_logs テーブルに保存されているデータ（key）の期待値を返却する
+     *
+     * @return array
+     */
+    private function getKeysExpected(): array
+    {
+        return [
+            'id',
+            'hub_id',
+            'user_id',
+            'created_at',
+            'updated_at',
+        ];
+    }
+
+    /**
+     * アクセスログ保存後に，access_logs テーブルに保存されているデータ（value）の期待値を返却する
+     *
+     * @param string|null $thread_idn
+     * @param User|null $user
+     * @return array
+     */
+    private function getValuesExpected(string $thread_id = null, User $user = null): array
+    {
+        $user_id = null;
+        if ($user !== null) {
+            $user_id = $user->id . '';
+        }
+
+        return [
+            'hub_id' => $thread_id ?? $this->thread->id . '',
+            'user_id' => $user_id,
+        ];
+    }
+
+    /**
+     * 渡された配列のうち，指定したインデックスの要素を返却する
+     *
+     * @param array $ary 連想配列
+     * @param array $keys 連想配列のインデックスを指定
+     * @return array インデックスと一致した連想配列を返却
+     */
+    private function getArrayElement(array $ary, array $keys): array
+    {
+        $response = [];
+        foreach ($keys as $key) {
+            $response[$key] = $ary[$key];
+        }
+        return $response;
+    }
+
+    /**
+     * リクエストインスタンスを取得する
+     *
+     * @param string|null $thread_idn
+     * @param User|null $user
+     * @return Request
+     */
+    private function getRequest(string $thread_id = null, User $user = null): Request
+    {
+        $request = new Request([
+            'thread_id' => $thread_id ?? $this->thread->id,
+        ]);
+        if ($user !== null) {
+            $request->setUserResolver(function () use ($user) {
+                return $user;
+            });
+        }
+
+        return $request;
+    }
+
+    /**
+     * ログインしていない状態でアクセスログを保存する
+     *
+     * @return void
+     */
+    public function test_store_access_logs_without_logging_in(): void
+    {
+        $this->assertSame(session()->get('thread_id'), null);
+
+        $response = (new AccessLog())->handle($this->getRequest(), function () {
+            //
+        });
+        $access_log = AccessLogs::where('hub_id', '=', $this->thread->id)
+            ->orderByDesc('id')
+            ->first()
+            ->toArray();
+
+        $this->assertSame(session()->get('thread_id'), $this->thread->id);
+        $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+        $this->assertSame(
+            $this->getValuesExpected(),
+            $this->getArrayElement($access_log, [
+                'hub_id',
+                'user_id',
+            ])
+        );
+    }
+
+    /**
+     * ログインしている状態でアクセスログを保存する
+     *
+     * @return void
+     */
+    public function test_store_access_logs_while_logged_in(): void
+    {
+        $this->assertSame(session()->get('thread_id'), null);
+
+        $response = (new AccessLog())->handle($this->getRequest(user: $this->user), function () {
+            //
+        });
+        $access_log = AccessLogs::where('hub_id', '=', $this->thread->id)
+            ->where('user_id', '=', $this->user->id)
+            ->orderByDesc('id')
+            ->first()
+            ->toArray();
+
+        $this->assertSame(session()->get('thread_id'), $this->thread->id);
+        $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+        $this->assertSame(
+            $this->getValuesExpected(user: $this->user),
+            $this->getArrayElement($access_log, [
+                'hub_id',
+                'user_id',
+            ])
+        );
+    }
+
+    /**
+     * ログインしていない状態で同じスレッドに複数回アクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_the_same_thread_multiple_times_without_being_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $this->thread->id);
+            }
+
+            $response = (new AccessLog())->handle($this->getRequest(), function () {
+                //
+            });
+            $access_log = AccessLogs::where('hub_id', '=', $this->thread->id)
+                ->orderByDesc('id')
+                ->first()
+                ->toArray();
+            $access_logs_count = AccessLogs::where('hub_id', '=', $this->thread->id)
+                ->count();
+
+            $this->assertSame(session()->get('thread_id'), $this->thread->id);
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * ログインしている状態で同じスレッドに複数回アクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_the_same_thread_multiple_times_while_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $this->thread->id);
+            }
+
+            $response = (new AccessLog())->handle($this->getRequest(user: $this->user), function () {
+                //
+            });
+            $access_log = AccessLogs::where('hub_id', '=', $this->thread->id)
+                ->where('user_id', '=', $this->user->id)
+                ->orderByDesc('id')
+                ->first()
+                ->toArray();
+            $access_logs_count = AccessLogs::where('hub_id', '=', $this->thread->id)
+                ->where('user_id', '=', $this->user->id)
+                ->count();
+
+            $this->assertSame(session()->get('thread_id'), $this->thread->id);
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(user: $this->user),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * ログインしていない状態で存在しないスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_non_existent_threads_without_being_logged_in(): void
+    {
+        $thread_id = 'non existent thread id';
+        $this->assertSame(session()->get('thread_id'), null);
+
+        $this->assertThrows(
+            fn () => (new AccessLog())->handle($this->getRequest(thread_id: $thread_id), function () {
+                //
+            }),
+            NotFoundHttpException::class
+        );
+
+        $access_log = AccessLogs::where('hub_id', '=', $thread_id)
+            ->get()
+            ->toArray() ?? null;
+        $this->assertSame(session()->get('thread_id'), null);
+        $this->assertSame([], $access_log);
+    }
+
+    /**
+     * ログインしている状態で存在しないスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_a_thread_that_does_not_exist_while_logged_in(): void
+    {
+        $thread_id = 'non existent thread id';
+        $this->assertSame(session()->get('thread_id'), null);
+
+        $this->assertThrows(
+            fn () => (new AccessLog())->handle($this->getRequest(thread_id: $thread_id, user: $this->user), function () {
+                //
+            }),
+            NotFoundHttpException::class
+        );
+
+        $access_log = AccessLogs::where('hub_id', '=', $thread_id)
+            ->get()
+            ->toArray() ?? null;
+        $this->assertSame(session()->get('thread_id'), null);
+        $this->assertSame([], $access_log);
+    }
+
+    /**
+     * ログインしていない状態で複数のスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_accessing_multiple_threads_without_being_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $thread->id . '');
+            }
+
+            $thread = Hub::factory()->create();
+            $response = (new AccessLog())->handle($this->getRequest(thread_id: $thread->id), function () {
+                //
+            });
+            $access_log = AccessLogs::where('hub_id', '=', $thread->id)
+                ->orderByDesc('id')
+                ->first()
+                ->toArray();
+            $access_logs_count = AccessLogs::where('hub_id', '=', $thread->id)
+                ->count();
+
+            $this->assertSame(session()->get('thread_id'), $thread->id . '');
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(thread_id: $thread->id),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+
+    /**
+     * ログインしている状態で複数のスレッドにアクセスする
+     *
+     * @return void
+     */
+    public function test_access_multiple_threads_while_logged_in(): void
+    {
+        foreach (range(1, random_int(2, 10)) as $num) {
+            if ($num === 1) {
+                $this->assertSame(session()->get('thread_id'), null);
+            } else {
+                $this->assertSame(session()->get('thread_id'), $thread->id . '');
+            }
+
+            $thread = Hub::factory()->create();
+            $response = (new AccessLog())->handle($this->getRequest(thread_id: $thread->id, user: $this->user), function () {
+                //
+            });
+            $access_log = AccessLogs::where('hub_id', '=', $thread->id)
+                ->orderByDesc('id')
+                ->first()
+                ->toArray();
+            $access_logs_count = AccessLogs::where('hub_id', '=', $thread->id)
+                ->count();
+
+            $this->assertSame(session()->get('thread_id'), $thread->id . '');
+            $this->assertSame($this->getKeysExpected(), array_keys($access_log));
+            $this->assertSame(
+                $this->getValuesExpected(thread_id: $thread->id, user: $this->user),
+                $this->getArrayElement($access_log, [
+                    'hub_id',
+                    'user_id',
+                ])
+            );
+            $this->assertSame(1, $access_logs_count);
+        }
+    }
+}


### PR DESCRIPTION
## 関連

- #172 
- #205 

## なぜこの変更をするのか

なし

## やったこと

- `access_logs` テーブルの `session_id`, `uri` カラムを削除
- スレッドアクセス時のみにアクセスログを保存するように変更
- 前回と同じスレッドにアクセスした際にはアクセスログを保存しないように変更
- 存在しないスレッドにアクセスした際にはアクセスログを保存せず，404ページを表示する

## やらないこと

- 存在しないスレッドにアクセスした際に「このスレッドは存在しません」などの専用メッセージを表示すること

## できるようになること（ユーザ目線）

- 存在しないスレッドにアクセスした際に，書き込みが何も表示されないスレッドが表示されるのではなく，404ページへ移動することができる

## できなくなること（ユーザ目線）

なし

## 動作確認

- スレッド以外へアクセスした際にアクセスログが保存されないことを確認
- スレッドアクセス時にF5などでリロードした際にアクセスログが増えないことを確認

## その他

- 存在しないスレッドにアクセスした際には専用メッセージを表示せずとも，404ページを表示するだけで十分かと思います．