### PR TITLE
HubControllerをサービスクラスとリポジトリクラスに分割

### DIFF
--- a/app/Consts/Tables/HubConst.php
+++ b/app/Consts/Tables/HubConst.php
@@ -12,7 +12,7 @@ class HubConst
 
     // カラム名
     const ID = 'id';
-    const THREAD_SECONDARY_CATEGORY_ID = ThreadSecondarYCategoryConst::USED_FOREIGN_KEY;
+    const THREAD_SECONDARY_CATEGORY_ID = ThreadSecondaryCategoryConst::USED_FOREIGN_KEY;
     const USER_ID = UserConst::USED_FOREIGN_KEY;
     const _NAME = 'name';
     const CREATED_AT = 'created_at';

--- a/app/Consts/Tables/ThreadSecondaryCategoryConst.php
+++ b/app/Consts/Tables/ThreadSecondaryCategoryConst.php
@@ -49,8 +49,11 @@ class ThreadSecondaryCategoryConst
     // 授業
     const CAREER_COURSES = 'キャリア科目';
 
-    // 保存された詳細カテゴリ名一覧
-    const SECONDARY_CATEGORYS = [
+    /*
+    | 大枠カテゴリカテゴリをkeyとして
+    | それに属する詳細カテゴリの配列を値とする連想配列
+    */
+    const PRIMARY_IN_SECONDARY_CATEGORYS = [
         ThreadPrimaryCategoryConst::CLUB => [
             self::HXS,
         ],
@@ -73,5 +76,21 @@ class ThreadSecondaryCategoryConst
         ThreadPrimaryCategoryConst::LECTURE => [
             self::CAREER_COURSES,
         ],
+    ];
+
+    // 保存された詳細カテゴリ名一覧
+    const SECONDARY_CATEGORYS = [
+        self::HXS,
+        self::FRESHMAN,
+        self::SOPHOMORE,
+        self::JUNIOR,
+        self::SENIOR,
+        self::_ID,
+        self::IC,
+        self::IS,
+        self::IM,
+        self::IN,
+        self::TWENTY_TWENTY_TWO,
+        self::CAREER_COURSES,
     ];
 }

--- a/app/Http/Controllers/Dashboard/HubController.php
+++ b/app/Http/Controllers/Dashboard/HubController.php
@@ -4,11 +4,18 @@ namespace App\Http\Controllers\Dashboard;
 
 use App\Http\Controllers\Controller;
 use App\Models\Hub;
-use App\Models\ThreadSecondaryCategory;
+use App\Services\HubService;
 use Illuminate\Http\Request;
 
 class HubController extends Controller
 {
+    private HubService $hubService;
+
+    public function __construct()
+    {
+        $this->hubService = new HubService;
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -32,7 +39,6 @@ class HubController extends Controller
     /**
      * [POST] スレッドを作成する．
      *
-     * @link https://readouble.com/laravel/9.x/ja/queries.html
      * @todo https://github.com/oithxs/hira-chan/issues/170
      *
      * @param  \Illuminate\Http\Request  $request
@@ -40,13 +46,11 @@ class HubController extends Controller
      */
     public function store(Request $request)
     {
-        $thread_category_id = ThreadSecondaryCategory::where('name', '=', $request->thread_category)->first()->id;
-
-        Hub::create([
-            'thread_secondary_category_id' => $thread_category_id,
-            'user_id' => $request->user()->id,
-            'name' => $request->thread_name
-        ]);
+        $this->hubService->store(
+            $request->thread_category,
+            $request->user()->id,
+            $request->thread_name
+        );
     }
 
     /**

--- a/app/Repositories/HubRepository.php
+++ b/app/Repositories/HubRepository.php
@@ -9,6 +9,26 @@ use App\Models\ThreadSecondaryCategory;
 class HubRepository
 {
     /**
+     * スレッドを作成する
+     *
+     * @param integer $threadSecondaryCategoryId スレッドが属する詳細カテゴリのID
+     * @param string $userId スレッドを作成するユーザのID
+     * @param string $name スレッド名
+     * @return void
+     */
+    public static function store(
+        int $threadSecondaryCategoryId,
+        string $userId,
+        string $name
+    ): void {
+        Hub::create([
+            'thread_secondary_category_id' => $threadSecondaryCategoryId,
+            'user_id' => $userId,
+            'name' => $name,
+        ]);
+    }
+
+    /**
      * id からスレッドを取得する
      *
      * @param string $threadId スレッドID

--- a/app/Repositories/ThreadSecondaryCategoryRepository.php
+++ b/app/Repositories/ThreadSecondaryCategoryRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\ThreadSecondaryCategory;
+
+class ThreadSecondaryCategoryRepository
+{
+    /**
+     * 詳細カテゴリ名からIDを取得する
+     *
+     * @param string $threadSecondaryCategoryName 詳細カテゴリ名
+     * @return integer|null 詳細カテゴリのID
+     */
+    public static function nameToId(string $threadSecondaryCategoryName): int | null
+    {
+        return ThreadSecondaryCategory::where([
+            ['name', $threadSecondaryCategoryName]
+        ])->first()->id ?? null;
+    }
+}

--- a/app/Services/HubService.php
+++ b/app/Services/HubService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\HubRepository;
+use App\Repositories\ThreadSecondaryCategoryRepository;
+
+class HubService
+{
+    /**
+     * スレッドを作成する
+     *
+     * @param string $threadSecondaryCategoryName 作成するスレッドが属する詳細カテゴリ名
+     * @param string $userId スレッドを作成するユーザのID
+     * @param string $threadName 作成するスレッド名
+     * @return void
+     */
+    public function store(
+        string $threadSecondaryCategoryName,
+        string $userId,
+        string $threadName
+    ): void {
+        HubRepository::store(
+            ThreadSecondaryCategoryRepository::nameToId($threadSecondaryCategoryName),
+            $userId,
+            $threadName
+        );
+    }
+}

--- a/tests/Support/AssertSame/Tables/HubTrait.php
+++ b/tests/Support/AssertSame/Tables/HubTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Support\AssertSame\Tables;
+
+use App\Consts\Tables\HubConst;
+use Tests\Support\ArrayToolsTrait;
+
+trait HubTrait
+{
+    use ArrayToolsTrait;
+
+    /**
+     * @var array 期待するhubテーブルのデータ
+     */
+    public array $hub;
+
+    /**
+     * hub テーブルすべてのカラム名を期待する値として取得する
+     *
+     * @return array hubテーブルのすべてのカラム名
+     */
+    public function getKeysExpected(): array
+    {
+        return HubConst::COLUMNS;
+    }
+
+    /**
+     * hub テーブルの一部のカラムのデータを実際の値として返却する
+     *
+     * @param array|null $args 引数は使用しない
+     * @return array hubテーブルの一部のカラムのデータ
+     */
+    public function getValuesActual(array $args = null): array
+    {
+        return $this->getArrayElement($this->hub, [
+            'thread_secondary_category_id',
+            'user_id',
+            'name',
+        ]);
+    }
+}

--- a/tests/Support/PostTestTrait.php
+++ b/tests/Support/PostTestTrait.php
@@ -39,7 +39,7 @@ trait PostTestTrait
     {
         $this->posts = [];
         for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
-            foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS[ThreadPrimaryCategoryConst::PRIMARY_CATEGORYS[$i]] as $secondary_category) {
+            foreach (ThreadSecondaryCategoryConst::PRIMARY_IN_SECONDARY_CATEGORYS[ThreadPrimaryCategoryConst::PRIMARY_CATEGORYS[$i]] as $secondary_category) {
                 $thread = Hub::factory()->create([
                     'thread_secondary_category_id' => ThreadSecondaryCategory::where('name', $secondary_category)->first()->id
                 ]);

--- a/tests/Support/Random.php
+++ b/tests/Support/Random.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Support;
+
+class Random
+{
+    /**
+     * 0~9の文字を利用してランダムな文字列を生成する
+     *
+     * @param integer $length 文字列の長さ
+     * @return string ランダムな文字列（すべて数字）
+     */
+    public static function stringOfNumbers(int $length = 10): string
+    {
+        $str = '';
+        while (strlen($str) < $length) {
+            $str .= (string) random_int(0, 9);
+        }
+        return $str;
+    }
+
+    /**
+     * 指定した配列の要素から，指定された文字長の文字列を生成する
+     *
+     * @param array $strings ランダムな文字列生成
+     * @param integer $length 生成する文字長
+     * @return string ランダムな文字列
+     */
+    public static function base(array $strings, int $length): string
+    {
+        $str = '';
+        while (strlen($str) < $length) {
+            $str .= $strings[random_int(0, count($strings) - 1)];
+        }
+        return $str;
+    }
+
+    /**
+     * 指定された文字長のランダムな英文字・記号・数字の文字列を生成する
+     *
+     * @param integer $length 生成する文字長
+     * @return string ランダムな英文字・記号・数字の文字列
+     */
+    public static function string(int $length = 10): string
+    {
+        return self::base(range('!', '~'), $length);
+    }
+
+    /**
+     * 指定された文字長のランダムな英小文字の文字列を生成する
+     *
+     * @param integer $length 生成する文字長
+     * @return string ランダムな英小文字の文字列
+     */
+    public static function lowercase(int $length = 10): string
+    {
+        return self::base(range('a', 'z'), $length);
+    }
+
+    /**
+     * 指定された文字長のランダムな英大文字の文字長を生成する
+     *
+     * @param integer $length 生成する文字長
+     * @return string ランダムな英大文字の文字列
+     */
+    public static function uppercase(int $length = 10): string
+    {
+        return self::base(range('A', 'Z'), $length);
+    }
+
+    /**
+     * 指定された文字長のランダムな英字の文字列を生成する
+     *
+     * @param integer $length 生成する文字長
+     * @return string ランダムな英字の文字列
+     */
+    public static function english(int $length = 10): string
+    {
+        return self::base(array_merge(
+            range('A', 'Z'),
+            range('a', 'z')
+        ), $length);
+    }
+
+    /**
+     * 指定された文字長のランダムな記号の文字列を生成する
+     *
+     * @param integer $length 生成する文字長
+     * @return string ランダムな記号の文字列
+     */
+    public static function symbol(int $length = 10): string
+    {
+        return self::base(array_merge(
+            range('!', '/'),
+            range(':', '@'),
+            range('[', '`'),
+            range('{', '~')
+        ), $length);
+    }
+}

--- a/tests/Unit/app/Http/Controllers/Dashboard/HubController/StoreTest.php
+++ b/tests/Unit/app/Http/Controllers/Dashboard/HubController/StoreTest.php
@@ -6,14 +6,13 @@ use App\Http\Controllers\Dashboard\HubController;
 use App\Models\Hub;
 use App\Models\ThreadSecondaryCategory;
 use App\Models\User;
-use ErrorException;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use SebastianBergmann\Type\VoidType;
 use Tests\UseFormRequestTestCase;
+use TypeError;
 
 class StoreTest extends UseFormRequestTestCase
 {
@@ -284,7 +283,7 @@ class StoreTest extends UseFormRequestTestCase
     {
         $this->assertThrows(
             fn () => $this->useFormRequest(['thread_category'], [Str::random(0)]),
-            ErrorException::class
+            TypeError::class
         );
     }
 
@@ -323,7 +322,7 @@ class StoreTest extends UseFormRequestTestCase
     {
         $this->assertThrows(
             fn () => $this->useFormRequest(['thread_category'], [now()]),
-            ErrorException::class
+            TypeError::class
         );
     }
 }

--- a/tests/Unit/app/Repositories/HubRepository/StoreTest.php
+++ b/tests/Unit/app/Repositories/HubRepository/StoreTest.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\HubRepository;
+
+use App\Models\Hub;
+use App\Models\ThreadSecondaryCategory;
+use App\Models\User;
+use App\Repositories\HubRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\HubTrait;
+use Tests\Support\Random;
+use Tests\TestCase;
+use TypeError;
+
+class StoreTest extends TestCase implements AssertSameInterface
+{
+    use HubTrait,
+        RefreshDatabase;
+
+    /**
+     * @var User テストで使用するユーザ
+     */
+    private User $user;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+        $this->method = [new HubRepository, 'store'];
+    }
+
+    /**
+     * スレッドの期待するデータを返却する
+     *
+     * @param array $args ['threadSecondaryCategoryId', 'userId', 'name']の要素が必要
+     * @return array 期待するhubテーブルに保存されたデータ
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected['thread_secondary_category_id'] = $args['threadSecondaryCategoryId'];
+        $expected['user_id'] = $args['userId'] . '';
+        $expected['name'] = $args['name'];
+        return $expected;
+    }
+
+    /**
+     * 対応するhubテーブルのデータを取得する
+     *
+     * このテストでは各詳細カテゴリごとに1つしかスレッドを作成しないため，
+     * 詳細カテゴリIDでスレッドを一意に識別することが可能
+     *
+     * @param integer $threadSecondaryCategoryId 詳細カテゴリID
+     * @return array 対応するhubテーブルすべてのカラム
+     */
+    private function getHub(int $threadSecondaryCategoryId): array
+    {
+        return Hub::where('thread_secondary_category_id', $threadSecondaryCategoryId)
+            ->first()->toArray();
+    }
+
+    /**
+     * hubテーブルすべてのデータを取得する
+     *
+     * @return array hubテーブルに保存されたすべてのデータ
+     */
+    private function getAllHub(): array
+    {
+        return Hub::get()->toArray();
+    }
+
+    /**
+     * thread_secondary_categorys テーブルのデータを取得する
+     *
+     * @return array thread_secondary_categorys テーブルすべてのデータ
+     */
+    private function getAllThreadSecondaryCategory(): array
+    {
+        return ThreadSecondaryCategory::get()->toArray();
+    }
+
+    /**
+     * thread_secondary_categorys テーブルのすべてのIDを取得する
+     *
+     * @return array thread_secondary_categorys テーブルのすべてのID
+     */
+    private function getAllThreadSecondaryCategoryIds(): array
+    {
+        $ids = [];
+        foreach ($this->getAllThreadSecondaryCategory() as $threadSecondaryCategory) {
+            $ids[] = $threadSecondaryCategory['id'];
+        }
+        return $ids;
+    }
+
+    /**
+     * getValuesActualメソッドで使用するメンバ変数「$hub」に値をセットする
+     *
+     * @param integer $threadSecondaryCategoryId 作成したスレッドが属する詳細カテゴリのID
+     * @param string $userId スレッドを作成したユーザのID
+     * @param string $name 作成したスレッド名
+     * @return void
+     */
+    private function setHub(
+        int $threadSecondaryCategoryId,
+        string $userId,
+        string $name
+    ): void {
+        $this->hub['thread_secondary_category_id'] = $threadSecondaryCategoryId;
+        $this->hub['user_id'] = $userId;
+        $this->hub['name'] = $name;
+    }
+
+    /**
+     * スレッドが作成できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatAThreadCanBeCreated(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $threadName = fake()->name;
+            ($this->method)(
+                $threadSecondaryCategoryId,
+                $this->user->id,
+                $threadName
+            );
+
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しない詳細カテゴリIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAThreadSecondaryCategoryIdThatDoesNotExist(): void
+    {
+        // 下限 - 1
+        $threadSecondaryCategoryId = 0;
+        $threadName = fake()->name;
+        $this->assertThrows(
+            fn () => ($this->method)(
+                $threadSecondaryCategoryId,
+                $this->user->id,
+                $threadName
+            ),
+            QueryException::class
+        );
+
+        // 上限 + 1
+        $threadSecondaryCategoryId = count($this->getAllThreadSecondaryCategory()) + 1;
+        $threadName = fake()->name;
+        $this->assertThrows(
+            fn () => ($this->method)(
+                $threadSecondaryCategoryId,
+                $this->user->id,
+                $threadName
+            ),
+            QueryException::class
+        );
+
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * 詳細カテゴリID未定義
+     *
+     * @return void
+     */
+    public function testThreadSecondaryCategoryIdUndefined(): void
+    {
+        $threadName = fake()->name;
+        $this->assertThrows(
+            fn () => ($this->method)(
+                userId: $this->user->id,
+                name: $threadName
+            ),
+            TypeError::class
+        );
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAUserIdThatDoesNotExist(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $userId = 'not existent user id';
+            $threadName = fake()->name;
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $threadSecondaryCategoryId,
+                    $userId,
+                    $threadName
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * ユーザID未定義
+     *
+     * @return void
+     */
+    public function testUserIdUndefined(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $threadName = fake()->name;
+
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadSecondaryCategoryId: $threadSecondaryCategoryId,
+                    name: $threadName
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * すべて数字の文字列をスレッド名とする
+     *
+     * @return void
+     */
+    public function testAllNumericThreadNames(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $threadName = Random::stringOfNumbers();
+            ($this->method)(
+                $threadSecondaryCategoryId,
+                $this->user->id,
+                $threadName
+            );
+
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+    /**
+     * すべて記号の文字列をスレッド名とする
+     *
+     * @return void
+     */
+    public function testAllSymbolicThreadNames(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $threadName = Random::symbol();
+            ($this->method)(
+                $threadSecondaryCategoryId,
+                $this->user->id,
+                $threadName
+            );
+
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+    /**
+     * 指定できる最大文字長の文字列をスレッド名とする
+     *
+     * @return void
+     */
+    public function testMaximumCharacterLengthThatCanBeSpecifiedIsTheThreadName(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $threadName = Random::string(255);
+            ($this->method)(
+                $threadSecondaryCategoryId,
+                $this->user->id,
+                $threadName
+            );
+
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+    /**
+     * 最大文字長を超えたものをスレッド名とする
+     *
+     * @return void
+     */
+    public function testThreadNameBeyondTheMaximumCharacterLength(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $threadName = Random::string(256);
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $threadSecondaryCategoryId,
+                    $this->user->id,
+                    $threadName
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * スレッド名未定義
+     *
+     * @return void
+     */
+    public function testThreadNameUndefined(): void
+    {
+        foreach ($this->getAllThreadSecondaryCategoryIds() as $threadSecondaryCategoryId) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadSecondaryCategoryId: $threadSecondaryCategoryId,
+                    userId: $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+}

--- a/tests/Unit/app/Repositories/ThreadPrimaryCategoryRepository/GetThreadSecondaryCategoryHasManyTest.php
+++ b/tests/Unit/app/Repositories/ThreadPrimaryCategoryRepository/GetThreadSecondaryCategoryHasManyTest.php
@@ -78,7 +78,7 @@ class GetThreadSecondaryCategoryHasManyTest extends TestCase implements AssertSa
                 $this->assertSame(
                     $this->getValuesExpected([
                         'primaryCategoryName' => $primaryCategoryName,
-                        'secondaryCategoryName' => ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS[$primaryCategoryName][$i],
+                        'secondaryCategoryName' => ThreadSecondaryCategoryConst::PRIMARY_IN_SECONDARY_CATEGORYS[$primaryCategoryName][$i],
                     ]),
                     $this->getValuesActual()
                 );

--- a/tests/Unit/app/Repositories/ThreadSecondaryCategoryRepository/NameToId.php
+++ b/tests/Unit/app/Repositories/ThreadSecondaryCategoryRepository/NameToId.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\ThreadSecondaryCategoryRepository;
+
+use App\Consts\Tables\ThreadPrimaryCategoryConst;
+use App\Consts\Tables\ThreadSecondaryCategoryConst;
+use App\Models\ThreadSecondaryCategory;
+use App\Repositories\ThreadSecondaryCategoryRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use TypeError;
+
+class NameToId extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new ThreadSecondaryCategoryRepository, 'nameToId'];
+    }
+
+    /**
+     * 詳細カテゴリ名から対応する詳細カテゴリのIDを取得する
+     *
+     * @param string $secondaryCategoryName 詳細カテゴリ名
+     * @return integer 対応する詳細カテゴリのID
+     */
+    public function getThreadSecondaryCategoryId(string $secondaryCategoryName): int
+    {
+        return ThreadSecondaryCategory::where('name', $secondaryCategoryName)->first()->id;
+    }
+
+    /**
+     * 詳細カテゴリのIDを取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheIdOfTheSecondaryCategoryCanBeObtained(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $this->assertSame(
+                $this->getThreadSecondaryCategoryId($secondaryCategoryName),
+                ($this->method)($secondaryCategoryName)
+            );
+        }
+    }
+
+    /**
+     * 存在しない詳細カテゴリ名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAThreadSecondaryCategoryNameThatDoesNotExists(): void
+    {
+        $threadSecondaryCategoryName = 'not existent thread secondary category name';
+        $this->assertSame(
+            null,
+            ($this->method)($threadSecondaryCategoryName)
+        );
+    }
+
+    /**
+     * 詳細カテゴリ名未定義
+     *
+     * @return void
+     */
+    public function testThreadSecondaryCategoryNameUNdefined(): void
+    {
+        $this->assertThrows(
+            fn () => ($this->method)(),
+            TypeError::class
+        );
+    }
+}

--- a/tests/Unit/app/Services/HubService/StoreTest.php
+++ b/tests/Unit/app/Services/HubService/StoreTest.php
@@ -1,0 +1,371 @@
+<?php
+
+namespace Tests\Unit\app\Services\HubService;
+
+use App\Consts\Tables\ThreadSecondaryCategoryConst;
+use App\Models\Hub;
+use App\Models\ThreadSecondaryCategory;
+use App\Models\User;
+use App\Services\HubService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\HubTrait;
+use Tests\Support\Random;
+use Tests\TestCase;
+use TypeError;
+
+class StoreTest extends TestCase implements AssertSameInterface
+{
+    use HubTrait,
+        RefreshDatabase;
+
+    /**
+     * @var User テストで使用するユーザ
+     */
+    private User $user;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+        $this->method = [new HubService, 'store'];
+    }
+
+    /**
+     * スレッドの期待するデータを返却する
+     *
+     * @param array $args ['threadSecondaryCategoryId', 'userId', 'name']の要素が必要
+     * @return array 期待するhubテーブルに保存されたデータ
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected['thread_secondary_category_id'] = $args['threadSecondaryCategoryId'];
+        $expected['user_id'] = $args['userId'] . '';
+        $expected['name'] = $args['name'];
+        return $expected;
+    }
+
+    /**
+     * 対応するhubテーブルのデータを取得する
+     *
+     * このテストでは各詳細カテゴリごとに1つしかスレッドを作成しないため，
+     * 詳細カテゴリIDでスレッドを一意に識別することが可能
+     *
+     * @param integer $threadSecondaryCategoryId 詳細カテゴリID
+     * @return array 対応するhubテーブルすべてのカラム
+     */
+    private function getHub(int $threadSecondaryCategoryId): array
+    {
+        return Hub::where('thread_secondary_category_id', $threadSecondaryCategoryId)
+            ->first()->toArray();
+    }
+
+    /**
+     * hubテーブルすべてのデータを取得する
+     *
+     * @return array hubテーブルに保存されたすべてのデータ
+     */
+    private function getAllHub(): array
+    {
+        return Hub::get()->toArray();
+    }
+
+    /**
+     * thread_secondary_categorys テーブルのデータを取得する
+     *
+     * @return array thread_secondary_categorys テーブルすべてのデータ
+     */
+    private function getAllThreadSecondaryCategory(): array
+    {
+        return ThreadSecondaryCategory::get()->toArray();
+    }
+
+    /**
+     * thread_secondary_categorys テーブルのすべてのIDを取得する
+     *
+     * @return array thread_secondary_categorys テーブルのすべてのID
+     */
+    private function getAllThreadSecondaryCategoryIds(): array
+    {
+        $ids = [];
+        foreach ($this->getAllThreadSecondaryCategory() as $threadSecondaryCategory) {
+            $ids[] = $threadSecondaryCategory['id'];
+        }
+        return $ids;
+    }
+
+    /**
+     * 詳細カテゴリ名からIDを取得する
+     *
+     * @param string $threadSecondaryCategoryName 詳細カテゴリ名
+     * @return integer|null 詳細カテゴリのID
+     */
+    private function nameToId(string $threadSecondaryCategoryName): int | null
+    {
+        return ThreadSecondaryCategory::where([
+            ['name', $threadSecondaryCategoryName]
+        ])->first()->id ?? null;
+    }
+
+    /**
+     * getValuesActualメソッドで使用するメンバ変数「$hub」に値をセットする
+     *
+     * @param integer $threadSecondaryCategoryId 作成したスレッドが属する詳細カテゴリのID
+     * @param string $userId スレッドを作成したユーザのID
+     * @param string $name 作成したスレッド名
+     * @return void
+     */
+    private function setHub(
+        int $threadSecondaryCategoryId,
+        string $userId,
+        string $name
+    ): void {
+        $this->hub['thread_secondary_category_id'] = $threadSecondaryCategoryId;
+        $this->hub['user_id'] = $userId;
+        $this->hub['name'] = $name;
+    }
+
+    /**
+     * スレッドが作成できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatAThreadCanBeCreated(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $threadName = fake()->name;
+            ($this->method)(
+                $secondaryCategoryName,
+                $this->user->id,
+                $threadName
+            );
+
+            $threadSecondaryCategoryId = $this->nameToId($secondaryCategoryName);
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しない詳細カテゴリ名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAThreadSecondaryCategoryNameThatDoesNotExist(): void
+    {
+        $threadSecondaryCategoryName = Random::english();
+        $threadName = fake()->name;
+        $this->assertThrows(
+            fn () => ($this->method)(
+                $threadSecondaryCategoryName,
+                $this->user->id,
+                $threadName
+            ),
+            TypeError::class
+        );
+
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * 詳細カテゴリ名未定義
+     *
+     * @return void
+     */
+    public function testThreadSecondaryCategoryNameUndefined(): void
+    {
+        $threadName = fake()->name;
+        $this->assertThrows(
+            fn () => ($this->method)(
+                userId: $this->user->id,
+                threadName: $threadName
+            ),
+            TypeError::class
+        );
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAUserIdThatDoesNotExist(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $userId = 'not existent user id';
+            $threadName = fake()->name;
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $secondaryCategoryName,
+                    $userId,
+                    $threadName
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * ユーザID未定義
+     *
+     * @return void
+     */
+    public function testUserIdUndefined(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $threadName = fake()->name;
+
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadSecondaryCategoryName: $secondaryCategoryName,
+                    threadName: $threadName
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * すべて数字の文字列をスレッド名とする
+     *
+     * @return void
+     */
+    public function testAllNumericThreadNames(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $threadName = Random::stringOfNumbers();
+            ($this->method)(
+                $secondaryCategoryName,
+                $this->user->id,
+                $threadName
+            );
+
+            $threadSecondaryCategoryId = $this->nameToId($secondaryCategoryName);
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+    /**
+     * すべて記号の文字列をスレッド名とする
+     *
+     * @return void
+     */
+    public function testAllSymbolicThreadNames(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $threadName = Random::symbol();
+            ($this->method)(
+                $secondaryCategoryName,
+                $this->user->id,
+                $threadName
+            );
+
+            $threadSecondaryCategoryId = $this->nameToId($secondaryCategoryName);
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+    /**
+     * 指定できる最大文字長の文字列をスレッド名とする
+     *
+     * @return void
+     */
+    public function testMaximumCharacterLengthThatCanBeSpecifiedIsTheThreadName(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $threadName = Random::string(255);
+            ($this->method)(
+                $secondaryCategoryName,
+                $this->user->id,
+                $threadName
+            );
+
+            $threadSecondaryCategoryId = $this->nameToId($secondaryCategoryName);
+            $this->setHub($threadSecondaryCategoryId, $this->user->id, $threadName);
+            $this->assertSame($this->getKeysExpected(), array_keys($this->getHub($threadSecondaryCategoryId)));
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'threadSecondaryCategoryId' => $threadSecondaryCategoryId,
+                    'userId' => $this->user->id,
+                    'name' => $threadName,
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+    /**
+     * 最大文字長を超えたものをスレッド名とする
+     *
+     * @return void
+     */
+    public function testThreadNameBeyondTheMaximumCharacterLength(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $threadName = Random::string(256);
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $secondaryCategoryName,
+                    $this->user->id,
+                    $threadName
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+
+    /**
+     * スレッド名未定義
+     *
+     * @return void
+     */
+    public function testThreadNameUndefined(): void
+    {
+        foreach (ThreadSecondaryCategoryConst::SECONDARY_CATEGORYS as $secondaryCategoryName) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadSecondaryCategoryName: $secondaryCategoryName,
+                    userId: $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllHub());
+    }
+}


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- 細かく分けた方が管理・更新がしやすいため

## やったこと

- hubテーブル関連の定数で取得できなかったものを修正
- HubRepositoryにスレッドを作成するメソッドを追加
- ThreadSecondaryCategoryConstの大枠カテゴリに属する詳細カテゴリを取得できる定数名を変更
- 詳細カテゴリテーブル関連の定数クラスに詳細カテゴリ一覧の定数を追加
- thread_secondary_categorys テーブル関連のクエリを入れるリポジトリクラスを作成
- hubテーブル関連のビジネスロジック（サービスクラス）の作成
- HubControllerの処理を分割したリポジトリクラスとサービスクラスを利用するように変更

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- テスト作成
- スレッドが作成できることを確認
- 作成したスレッドへ書き込み・画像アップロード・書き込みの取得ができることを確認

## その他

なし