### PR TITLE
LikeControllerをサービスクラスとリポジトリクラスに分割

### DIFF
--- a/app/Consts/Tables/LikeConst.php
+++ b/app/Consts/Tables/LikeConst.php
@@ -9,4 +9,28 @@ class LikeConst
 
     // 外部キーとして利用されるときのカラム名
     const USED_FOREIGN_KEY = 'like_id';
+
+    // カラム名
+    const ID = 'id';
+    const CLUB_THREAD_ID = ClubThreadConst::USED_FOREIGN_KEY;
+    const COLLEGE_YEAR_THREAD_ID = CollegeYearThreadConst::USED_FOREIGN_KEY;
+    const DEPARTMENT_THREAD_ID = DepartmentThreadConst::USED_FOREIGN_KEY;
+    const JOB_HUNTING_THREAD_ID = JobHuntingThreadConst::USED_FOREIGN_KEY;
+    const LECTURE_THREAD_ID = LectureThreadConst::USED_FOREIGN_KEY;
+    const USER_ID = UserConst::USED_FOREIGN_KEY;
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
+
+    // カラム一覧
+    const COLUMNS = [
+        self::ID,
+        self::CLUB_THREAD_ID,
+        self::COLLEGE_YEAR_THREAD_ID,
+        self::DEPARTMENT_THREAD_ID,
+        self::JOB_HUNTING_THREAD_ID,
+        self::LECTURE_THREAD_ID,
+        self::USER_ID,
+        self::CREATED_AT,
+        self::UPDATED_AT,
+    ];
 }

--- a/app/Http/Controllers/Dashboard/LikeController.php
+++ b/app/Http/Controllers/Dashboard/LikeController.php
@@ -97,7 +97,6 @@ class LikeController extends Controller
     /**
      * [POST] スレッドの書き込みに対するいいねを削除する
      *
-     * @link https://readouble.com/laravel/9.x/ja/queries.html
      * @todo https://github.com/oithxs/hira-chan/issues/227
      *
      * @param  \Illuminate\Htt\Request $request
@@ -105,63 +104,11 @@ class LikeController extends Controller
      */
     public function destroy(Request $request)
     {
-        $thread = Hub::with('thread_secondary_category')
-            ->where('id', '=', $request->thread_id)
-            ->first();
-
-        switch ($thread->thread_secondary_category->thread_primary_category->name) {
-            case '部活':
-                $club_thread_id = ClubThread::where('hub_id', '=', $request->thread_id)
-                    ->where('message_id', '=', $request->message_id)
-                    ->first()
-                    ->id;
-                Like::where('club_thread_id', '=', $club_thread_id)
-                    ->where('user_id', '=', $request->user()->id)
-                    ->delete();
-                return Like::where('club_thread_id', '=', $club_thread_id)->count();
-
-            case '学年':
-                $college_year_thread_id = CollegeYearThread::where('hub_id', '=', $request->thread_id)
-                    ->where('message_id', '=', $request->message_id)
-                    ->first()
-                    ->id;
-                Like::where('college_year_thread_id', '=', $college_year_thread_id)
-                    ->where('user_id', '=', $request->user()->id)
-                    ->delete();
-                return Like::where('college_year_thread_id', '=', $college_year_thread_id)->count();
-
-            case '学科':
-                $department_thread_id = DepartmentThread::where('hub_id', '=', $request->thread_id)
-                    ->where('message_id', '=', $request->message_id)
-                    ->first()
-                    ->id;
-                Like::where('department_thread_id', '=', $department_thread_id)
-                    ->where('user_id', '=', $request->user()->id)
-                    ->delete();
-                return Like::where('department_thread_id', '=', $department_thread_id)->count();
-
-            case '就職':
-                $job_hunting_thread_id = JobHuntingThread::where('hub_id', '=', $request->thread_id)
-                    ->where('message_id', '=', $request->message_id)
-                    ->first()
-                    ->id;
-                Like::where('job_hunting_thread_id', '=', $job_hunting_thread_id)
-                    ->where('user_id', '=', $request->user()->id)
-                    ->delete();
-                return Like::where('job_hunting_thread_id', '=', $job_hunting_thread_id)->count();
-
-            case '授業':
-                $lecture_thread_id = LectureThread::where('hub_id', '=', $request->thread_id)
-                    ->where('message_id', '=', $request->message_id)
-                    ->first()
-                    ->id;
-                Like::where('lecture_thread_id', '=', $lecture_thread_id)
-                    ->where('user_id', '=', $request->user()->id)
-                    ->delete();
-                return Like::where('lecture_thread_id', '=', $lecture_thread_id)->count();
-
-            default:
-                return 0;
-        }
+        $this->likeService->destroy(
+            $request->thread_id,
+            $request->message_id,
+            $request->user()->id
+        );
+        return $this->likeService->countLike();
     }
 }

--- a/app/Http/Controllers/Dashboard/LikeController.php
+++ b/app/Http/Controllers/Dashboard/LikeController.php
@@ -100,9 +100,9 @@ class LikeController extends Controller
      * @todo https://github.com/oithxs/hira-chan/issues/227
      *
      * @param  \Illuminate\Htt\Request $request
-     * @return int
+     * @return integer いいねを削除した書き込みがされているいいね数
      */
-    public function destroy(Request $request)
+    public function destroy(Request $request): int
     {
         $this->likeService->destroy(
             $request->thread_id,

--- a/app/Repositories/LikeRepository.php
+++ b/app/Repositories/LikeRepository.php
@@ -23,6 +23,22 @@ class LikeRepository
     }
 
     /**
+     * 書き込みへのいいねを削除する
+     *
+     * @param string $foreignKey 書き込みを保存しているテーブルの外部キー名
+     * @param integer $postId 書き込みのID
+     * @param string $userId いいねを削除するユーザのID
+     * @return void
+     */
+    public static function destroy(string $foreignKey, int $postId, string $userId): void
+    {
+        Like::where([
+            [$foreignKey, $postId],
+            ['user_id', $userId],
+        ])->delete();
+    }
+
+    /**
      * 対応する書き込みのいいね数を取得する
      *
      * @param string $foreignKey 書き込みを保存しているテーブルの外部キー名

--- a/app/Repositories/LikeRepository.php
+++ b/app/Repositories/LikeRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Like;
+
+class LikeRepository
+{
+    /**
+     * 書き込みへのいいねを保存する
+     *
+     * @param string $foreignKey 書き込みを保存しているテーブルの外部キー名
+     * @param integer $postId 書き込みのID
+     * @param string $userId いいねをするユーザのID
+     * @return void
+     */
+    public static function store(string $foreignKey, int $postId, string $userId): void
+    {
+        Like::create([
+            $foreignKey => $postId,
+            'user_id' => $userId
+        ]);
+    }
+
+    /**
+     * 対応する書き込みのいいね数を取得する
+     *
+     * @param string $foreignKey 書き込みを保存しているテーブルの外部キー名
+     * @param integer $postId 書き込みのID
+     * @return integer 書き込みのいいね数
+     */
+    public static function countLike(string $foreignKey, int $postId): int
+    {
+        return Like::where($foreignKey, $postId)->count();
+    }
+}

--- a/app/Repositories/ThreadRepository.php
+++ b/app/Repositories/ThreadRepository.php
@@ -165,7 +165,7 @@ class ThreadRepository
      * @param string $model 書き込みを取得したいモデルクラス
      * @param string $threadId 書き込みを取得したいスレッドのID
      * @param integer $messageId 書き込みを取得したいメッセージのID
-     * @return integer|null 書き込み
+     * @return integer|null 書き込みのID
      */
     public static function findId(string $model, string $threadId, int $messageId): int | null
     {

--- a/app/Repositories/ThreadRepository.php
+++ b/app/Repositories/ThreadRepository.php
@@ -142,4 +142,33 @@ class ThreadRepository
     {
         return self::postToThreadPrimaryCategory($post)->name;
     }
+
+    /**
+     * 書き込みを取得する
+     *
+     * @param string $model 書き込みを取得したいモデルクラス
+     * @param string $threadId 書き込みを取得したいスレッドのID
+     * @param integer $messageId 書き込みを取得したいメッセージのID
+     * @return ThreadModel|null 書き込み
+     */
+    public static function find(string $model, string $threadId, int $messageId): ThreadModel | null
+    {
+        return $model::where([
+            ['hub_id', $threadId],
+            ['message_id', $messageId]
+        ])->first();
+    }
+
+    /**
+     * 書き込みのIDを取得する
+     *
+     * @param string $model 書き込みを取得したいモデルクラス
+     * @param string $threadId 書き込みを取得したいスレッドのID
+     * @param integer $messageId 書き込みを取得したいメッセージのID
+     * @return integer|null 書き込み
+     */
+    public static function findId(string $model, string $threadId, int $messageId): int | null
+    {
+        return self::find($model, $threadId, $messageId)->id ?? null;
+    }
 }

--- a/app/Services/LikeService.php
+++ b/app/Services/LikeService.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\LikeRepository;
+use App\Repositories\ThreadRepository;
+
+class LikeService
+{
+    private ThreadService $threadService;
+
+    /**
+     * @var string|null 外部キー名
+     */
+    private string | null $foreignKey;
+
+    /**
+     * @var integer|null 書き込みのID
+     */
+    private int | null $postId;
+
+    public function __construct()
+    {
+        $this->threadService = new ThreadService;
+        $this->foreignKey = null;
+        $this->postId = null;
+    }
+
+    /**
+     * 書き込みにいいねをする
+     *
+     * @param string $threadId いいねをする書き込みのスレッドID
+     * @param string $messageId いいねをする書き込みのメッセージID
+     * @param string $userId いいねをするユーザID
+     * @return void
+     */
+    public function store(string $threadId, string $messageId, string $userId): void
+    {
+        $this->foreignKey = $this->threadService->threadIdToForeignKey($threadId);
+        $this->postId = ThreadRepository::findId(
+            $this->threadService->threadIdToModel($threadId),
+            $threadId,
+            $messageId
+        );
+        LikeRepository::store(
+            $this->foreignKey,
+            $this->postId,
+            $userId
+        );
+    }
+
+    /**
+     * 指定された書き込みにされたいいね数をカウントする
+     *
+     * @param string|null $foreignKey 書き込みを保存しているテーブルの外部キー名
+     * @param integer|null $postId 書き込みのID
+     * @return integer 書き込みのいいね数
+     */
+    public function countLike(string $foreignKey = null, int $postId = null): int
+    {
+        return LikeRepository::countLike(
+            $foreignKey ?? $this->foreignKey,
+            $postId ?? $this->postId
+        );
+    }
+}

--- a/app/Services/LikeService.php
+++ b/app/Services/LikeService.php
@@ -50,6 +50,29 @@ class LikeService
     }
 
     /**
+     * 書き込みのいいねを削除する
+     *
+     * @param string $threadId 削除する，いいねがついた書き込みのスレッドID
+     * @param string $messageId 削除する，いいねがついた書き込みのメッセージID
+     * @param string $userId 削除するいいねをつけたユーザID
+     * @return void
+     */
+    public function destroy(string $threadId, string $messageId, string $userId): void
+    {
+        $this->foreignKey = $this->threadService->threadIdToForeignKey($threadId);
+        $this->postId = ThreadRepository::findId(
+            $this->threadService->threadIdToModel($threadId),
+            $threadId,
+            $messageId
+        );
+        LikeRepository::destroy(
+            $this->foreignKey,
+            $this->postId,
+            $userId
+        );
+    }
+
+    /**
      * 指定された書き込みにされたいいね数をカウントする
      *
      * @param string|null $foreignKey 書き込みを保存しているテーブルの外部キー名

--- a/app/Services/ThreadService.php
+++ b/app/Services/ThreadService.php
@@ -8,6 +8,7 @@ use App\Consts\Tables\DepartmentThreadConst;
 use App\Consts\Tables\JobHuntingThreadConst;
 use App\Consts\Tables\LectureThreadConst;
 use App\Models\ThreadModel;
+use App\Repositories\HubRepository;
 use App\Repositories\ThreadRepository;
 use App\Services\TableService;
 
@@ -66,6 +67,33 @@ class ThreadService
     {
         $tableConst = $this->getTableConst($threadPrimaryCategoryName);
         return $tableConst !== null ? $tableConst::NAME : '';
+    }
+
+    /**
+     * スレッドIDから外部キー名を取得する
+     *
+     * @param string $threadId 外部キー名を取得したいスレッドID
+     * @return string 外部キー名
+     */
+    public function threadIdToForeignKey(string $threadId): string
+    {
+        $threadPrimaryCategoryName = HubRepository::getThreadPrimaryCategoryName($threadId);
+        return $this->tableService->makeForeignKeyName(
+            $this->getTableName($threadPrimaryCategoryName)
+        );
+    }
+
+    /**
+     * スレッドIDからモデルクラスを取得する
+     *
+     * @param string $threadId モデルクラスを取得したいスレッドID
+     * @return string モデルクラス名
+     */
+    public function threadIdToModel(string $threadId): string
+    {
+        return $this->getThreadClassName(
+            HubRepository::getThreadPrimaryCategoryName($threadId)
+        );
     }
 
     /**

--- a/tests/Support/AssertSame/Tables/LikeTrait.php
+++ b/tests/Support/AssertSame/Tables/LikeTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Support\AssertSame\Tables;
+
+use App\Consts\Tables\LikeConst;
+use Tests\Support\ArrayToolsTrait;
+
+trait LikeTrait
+{
+    use ArrayToolsTrait;
+
+    /**
+     * @var array 実際のlikeテーブルのデータ
+     */
+    public array $like;
+
+    /**
+     * likes テーブルのすべてのカラム名を期待する値として取得する
+     *
+     * @return array hubsテーブルのすべてのカラム名
+     */
+    public function getKeysExpected(): array
+    {
+        return LikeConst::COLUMNS;
+    }
+
+    /**
+     * likes テーブルの実際の値を取得する
+     *
+     * @param array|null $args
+     * @return array
+     */
+    public function getValuesActual(array $args = null): array
+    {
+        return $this->getArrayElement($this->like, [
+            LikeConst::CLUB_THREAD_ID,
+            LikeConst::COLLEGE_YEAR_THREAD_ID,
+            LikeConst::DEPARTMENT_THREAD_ID,
+            LikeConst::JOB_HUNTING_THREAD_ID,
+            LikeConst::LECTURE_THREAD_ID,
+            LikeConst::USER_ID,
+        ]);
+    }
+}

--- a/tests/Support/AssertSame/Tables/LikeTrait.php
+++ b/tests/Support/AssertSame/Tables/LikeTrait.php
@@ -27,8 +27,8 @@ trait LikeTrait
     /**
      * likes テーブルの実際の値を取得する
      *
-     * @param array|null $args
-     * @return array
+     * @param array|null $args 値は使用しない
+     * @return array likesテーブルの実際のデータ
      */
     public function getValuesActual(array $args = null): array
     {

--- a/tests/Support/LikeTestTrait.php
+++ b/tests/Support/LikeTestTrait.php
@@ -22,7 +22,7 @@ trait LikeTestTrait
      * すべての大枠カテゴリの書き込みをメンバ変数に代入し，
      * すべての書き込みにいいねをする
      *
-     * @param integer $num
+     * @param integer $num 書き込みにつけるいいね数
      * @return void
      */
     public function likeSetUp(int $num = 10): void

--- a/tests/Support/LikeTestTrait.php
+++ b/tests/Support/LikeTestTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Models\ThreadModel;
+
+trait LikeTestTrait
+{
+    /**
+     * @var array スレッドへの書き込み
+     */
+    public array $posts;
+
+    /**
+     * @var array 書き込みへのいいね
+     */
+    public array $likes;
+
+    /**
+     * すべての大枠カテゴリの書き込みをメンバ変数に代入し，
+     * すべての書き込みにいいねをする
+     *
+     * @param integer $num
+     * @return void
+     */
+    public function likeSetUp(int $num = 10): void
+    {
+        $this->posts = [];
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $this->posts[$i] = ThreadsConst::MODEL_FQCNS[$i]::factory()->create();
+            for ($j = 0; $j < $num; $j++) {
+                $this->likes[$i][$j] = Like::factory()->post($this->posts[$i])->create();
+            }
+        }
+    }
+}

--- a/tests/Unit/app/Http/Controllers/Dashboard/LikeController/DestroyTest.php
+++ b/tests/Unit/app/Http/Controllers/Dashboard/LikeController/DestroyTest.php
@@ -18,6 +18,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Tests\UseFormRequestTestCase;
+use TypeError;
 
 class DestroyTest extends UseFormRequestTestCase
 {
@@ -225,7 +226,7 @@ class DestroyTest extends UseFormRequestTestCase
         foreach ($this->threads as $thread) {
             $this->assertThrows(
                 fn () => $this->useFormRequest(['thread_id', 'message_id'], [$thread->hub_id, Str::random(0)]),
-                ErrorException::class
+                TypeError::class
             );
         }
     }
@@ -245,7 +246,7 @@ class DestroyTest extends UseFormRequestTestCase
             foreach (range('a', 'z') as $str) {
                 $this->assertThrows(
                     fn () => $this->useFormRequest(['thread_id', 'message_id'], [$thread->hub_id, $str]),
-                    ErrorException::class
+                    TypeError::class
                 );
             }
         }
@@ -273,7 +274,7 @@ class DestroyTest extends UseFormRequestTestCase
             foreach ($symbols as $symbol) {
                 $this->assertThrows(
                     fn () => $this->useFormRequest(['thread_id', 'message_id'], [$thread->hub_id, $symbol]),
-                    ErrorException::class
+                    TypeError::class
                 );
             }
         }

--- a/tests/Unit/app/Http/Controllers/Dashboard/LikeController/StoreTest.php
+++ b/tests/Unit/app/Http/Controllers/Dashboard/LikeController/StoreTest.php
@@ -15,6 +15,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Tests\UseFormRequestTestCase;
+use TypeError;
 
 class StoreTest extends UseFormRequestTestCase
 {
@@ -219,7 +220,7 @@ class StoreTest extends UseFormRequestTestCase
         foreach ($this->threads as $thread) {
             $this->assertThrows(
                 fn () => $this->useFormRequest(['thread_id', 'message_id'], [$thread->hub_id, Str::random(0)]),
-                ErrorException::class
+                TypeError::class
             );
         }
     }
@@ -239,7 +240,7 @@ class StoreTest extends UseFormRequestTestCase
             foreach (range('a', 'z') as $str) {
                 $this->assertThrows(
                     fn () => $this->useFormRequest(['thread_id', 'message_id'], [$thread->hub_id, $str]),
-                    ErrorException::class
+                    TypeError::class
                 );
             }
         }
@@ -267,7 +268,7 @@ class StoreTest extends UseFormRequestTestCase
             foreach ($symbols as $symbol) {
                 $this->assertThrows(
                     fn () => $this->useFormRequest(['thread_id', 'message_id'], [$thread->hub_id, $symbol]),
-                    ErrorException::class
+                    TypeError::class
                 );
             }
         }

--- a/tests/Unit/app/Repositories/LikeRepository/CountLikeTest.php
+++ b/tests/Unit/app/Repositories/LikeRepository/CountLikeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\LikeRepository;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Models\ThreadModel;
+use App\Repositories\LikeRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\PostTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class CountLikeTest extends TestCase
+{
+    use PostTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->postSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new LikeRepository, 'countLike'];
+    }
+
+    /**
+     * 書き込みに指定された範囲内のランダムな数，
+     * いいねをする
+     *
+     * @param ThreadModel $post いいねをする書き込み
+     * @param integer $max いいねをするランダムな範囲の最大数
+     * @param integer $min いいねをするランダムな範囲の最小数
+     * @return integer 指定された書き込みにいいねをした数
+     */
+    private function setLikes(ThreadModel $post, $max = 20, $min = 10): int
+    {
+        $num = random_int($min, $max);
+        foreach (range(1, $num) as $_) {
+            Like::factory()->post($post)->create();
+        }
+        return $num;
+    }
+
+    /**
+     * 書き込みのいいね数を取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatCanGetTheNumberOfLikesForAPost(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+
+            $response = ($this->method)(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $this->posts[$i]->id
+            );
+            $this->assertSame($likes_num, $response);
+        }
+    }
+
+    /**
+     * 存在しない外部キー名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAForeignKeyThatDoesNotExist(): void
+    {
+        $foreignKey = 'not existent foreign key';
+        foreach ($this->posts as $post) {
+            $this->setLikes($post);
+            $this->assertThrows(
+                fn () => ($this->method)($foreignKey, $post->id),
+                QueryException::class
+            );
+        }
+    }
+
+    /**
+     * 外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefined(): void
+    {
+        foreach ($this->posts as $post) {
+            $this->setLikes($post);
+            $this->assertThrows(
+                fn () => ($this->method)(postId: $post->id),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * 存在しない書き込みIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAPostIdThatDoesNotExist(): void
+    {
+        $postId = -1;
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->setLikes($this->posts[$i]);
+            $response = ($this->method)(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $postId
+            );
+            $this->assertSame(0, $response);
+        }
+    }
+
+    /**
+     * 外部キー名未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->setLikes($this->posts[$i]);
+            $this->assertThrows(
+                fn () => ($this->method)(foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i]),
+                TypeError::class
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Repositories/LikeRepository/DestroyTest.php
+++ b/tests/Unit/app/Repositories/LikeRepository/DestroyTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\LikeRepository;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Repositories\LikeRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\LikeTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class DestroyTest extends TestCase
+{
+    use LikeTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->likeSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new LikeRepository, 'destroy'];
+    }
+
+    /**
+     * 対応するいいねを取得する
+     *
+     * @param string|null $foreignKey 書き込みを保存しているテーブルの外部キー
+     * @param integer $postId 書き込みのID
+     * @param string $userId いいねをしたユーザのID
+     * @return array 書き込みにつけたいいねのデータ
+     */
+    private function getLike(
+        string | null $foreignKey,
+        int $postId,
+        string $userId
+    ): array {
+        $where = [];
+        is_null($foreignKey) ?: $where[] = [$foreignKey, $postId];
+        $where[] = ['user_id', $userId];
+
+        return Like::where($where)->get()->toArray();
+    }
+
+    /**
+     * likesテーブルの全データを取得する
+     *
+     * @return array likesテーブルの全データ
+     */
+    private function getAllLike(): array
+    {
+        return Like::get()->toArray();
+    }
+
+    /**
+     * 書き込みのいいねが削除されることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatThePostLikesWillBeDeleted(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                ($this->method)(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $this->posts[$i]->id,
+                    $this->likes[$i][$j]->user_id
+                );
+                $this->assertSame(
+                    [],
+                    $this->getLike(
+                        ThreadsConst::USED_FOREIGN_KEYS[$i],
+                        $this->posts[$i]->id,
+                        $this->likes[$i][$j]->user_id
+                    )
+                );
+            }
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 存在しない外部キー名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAForeignKeyThatDoesNotExist(): void
+    {
+        $foreignKey = 'not existent foreign key';
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        $foreignKey,
+                        $this->posts[$i]->id,
+                        $this->likes[$i][$j]->user_id
+                    ),
+                    QueryException::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * 外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefined(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        postId: $this->posts[$i]->id,
+                        userId: $this->likes[$i][$j]->user_id
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * 存在しない書き込みIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAPostIdThatDoesNotExist(): void
+    {
+        $postId = -1;
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                ($this->method)(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $postId,
+                    $this->likes[$i][$j]->user_id
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * 書き込みID未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i],
+                        userId: $this->likes[$i][$j]->user_id
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAUserIdThatDoesNotExist(): void
+    {
+        $userId = 'not existent user id';
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                ($this->method)(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $this->posts[$i]->id,
+                    $userId
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * ユーザID未定義
+     *
+     * @return void
+     */
+    public function testUserIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i],
+                        postId: $this->posts[$i]->id,
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+}

--- a/tests/Unit/app/Repositories/LikeRepository/StoreTest.php
+++ b/tests/Unit/app/Repositories/LikeRepository/StoreTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\LikeRepository;
+
+use App\Consts\Tables\LikeConst;
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Models\User;
+use App\Repositories\LikeRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\LikeTrait;
+use Tests\Support\PostTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class StoreTest extends TestCase implements AssertSameInterface
+{
+    use LikeTrait,
+        PostTestTrait,
+        RefreshDatabase;
+
+    private User $user;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->postSetUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+        $this->method = [new LikeRepository, 'store'];
+    }
+
+    /**
+     * likesテーブルの期待するデータを取得する
+     *
+     * @param array $args ['外部キー名' => 書き込みのID, 'userId'] が必要
+     * @return array likesテーブルの期待するデータ
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        foreach (ThreadsConst::USED_FOREIGN_KEYS as $foreignKey) {
+            $expected[$foreignKey] = $args[$foreignKey] ?? null;
+        }
+        $expected[LikeConst::USER_ID] = $args['userId'] . '';
+        return $expected;
+    }
+
+    /**
+     * 対応するいいねを取得する
+     *
+     * @param string|null $foreignKey 書き込みを保存しているテーブルの外部キー
+     * @param integer $postId 書き込みのID
+     * @param string $userId いいねをしたユーザのID
+     * @return array 書き込みにつけたいいねのデータ
+     */
+    private function getLike(string | null $foreignKey, int $postId, string $userId): array
+    {
+        $where = [];
+        is_null($foreignKey) ?: $where[] = [$foreignKey, $postId];
+        $where[] = ['user_id', $userId];
+
+        return Like::where($where)->first()->toArray();
+    }
+
+    /**
+     * likesテーブルの全データを取得する
+     *
+     * @return array likesテーブルの全データ
+     */
+    private function getAllLike(): array
+    {
+        return Like::get()->toArray();
+    }
+
+    /**
+     * 投稿にいいねができることアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatACanLikeThePost(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            ($this->method)(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $this->posts[$i]->id,
+                $this->user->id
+            );
+
+            $this->like = $this->getLike(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $this->posts[$i]->id,
+                $this->user->id
+            );
+            $this->assertSame($this->getKeysExpected(), array_keys($this->like));
+            $this->assertSame($this->getValuesExpected([
+                ThreadsConst::USED_FOREIGN_KEYS[$i] => $this->posts[$i]->id,
+                'userId' => $this->user->id
+            ]), $this->getValuesActual());
+        }
+    }
+
+    /**
+     * 同じ書き込みに複数のいいねができることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatACanHaveMultipleLikesOnTheSamePost(): void
+    {
+        $users = [];
+        foreach (range(1, 10) as $_) {
+            $users[] = User::factory()->create();
+        }
+
+        for ($i = 0; $i < count($this->posts); $i++) {
+            foreach ($users as $user) {
+                ($this->method)(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $this->posts[$i]->id,
+                    $user->id
+                );
+            }
+
+            foreach ($users as $user) {
+                $this->like = $this->getLike(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $this->posts[$i]->id,
+                    $user->id
+                );
+                $this->assertSame($this->getKeysExpected(), array_keys($this->like));
+                $this->assertSame($this->getValuesExpected([
+                    ThreadsConst::USED_FOREIGN_KEYS[$i] => $this->posts[$i]->id,
+                    'userId' => $user->id
+                ]), $this->getValuesActual());
+            }
+        }
+    }
+
+    /**
+     * 存在しない外部キー名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAForeignKeyThatDoesNotExist(): void
+    {
+        $foreignKey = 'not existent foreign key';
+
+        foreach ($this->posts as $post) {
+            ($this->method)(
+                $foreignKey,
+                $post->id,
+                $this->user->id
+            );
+        }
+
+        $this->like = $this->getLike(null, $post->id, $this->user->id);
+        $this->assertSame($this->getKeysExpected(), array_keys($this->like));
+        $this->assertSame($this->getValuesExpected([
+            'userId' => $this->user->id
+        ]), $this->getValuesActual());
+    }
+
+    /**
+     * 外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    postId: $this->posts[$i]->id,
+                    userId: $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 存在しない書き込みIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAPostIdThatDoesNotExist(): void
+    {
+        $postId = -1;
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $postId,
+                    $this->user->id
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 書き込みID未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    userId: $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAUserIdThatDoesNotExist(): void
+    {
+        $userId = 'not existent user id';
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $this->posts[$i]->id,
+                    $userId
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * ユーザID未定義
+     *
+     * @return void
+     */
+    public function testUserIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    postId: $this->posts[$i]->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+}

--- a/tests/Unit/app/Repositories/ThreadRepository/FindIdTest.php
+++ b/tests/Unit/app/Repositories/ThreadRepository/FindIdTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\ThreadRepository;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Repositories\ThreadRepository;
+use Error;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\PostTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class FindIdTest extends TestCase
+{
+    use PostTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->postSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new ThreadRepository, 'findId'];
+    }
+
+    /**
+     * 書き込みのIDが取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheIdOfPostCanBeRetrieved(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $response = ($this->method)(
+                ThreadsConst::MODEL_FQCNS[$i],
+                $this->posts[$i]->hub_id,
+                $this->posts[$i]->message_id
+            );
+            $this->assertSame($this->posts[$i]->id, $response);
+        }
+    }
+
+    /**
+     * 存在しないモデルを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAModelThatDoesNotExists(): void
+    {
+        $model = 'not existent model';
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $model,
+                    $this->posts[$i]->hub_id,
+                    $this->posts[$i]->message_id
+                ),
+                Error::class
+            );
+        }
+    }
+
+    /**
+     * モデル未定義
+     *
+     * @return void
+     */
+    public function testModelUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadId: $this->posts[$i]->hub_id,
+                    messageId: $this->posts[$i]->message_id
+                ),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * 存在しないスレッドIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAThreadIdThatDoesNotExists(): void
+    {
+        $threadId = 'not existent thread id';
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $response = ($this->method)(
+                ThreadsConst::MODEL_FQCNS[$i],
+                $threadId,
+                $this->posts[$i]->message_id
+            );
+            $this->assertSame(null, $response);
+        }
+    }
+
+    /**
+     * スレッドID未定義
+     *
+     * @return void
+     */
+    public function testThreadIdUndefined(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    model: ThreadsConst::MODEL_FQCNS[$i],
+                    messageId: $this->posts[$i]->message_id
+                ),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * 存在しないメッセージIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAMessageIdThatDoesNotExists(): void
+    {
+        $messageId = -1;
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $response = ($this->method)(
+                ThreadsConst::MODEL_FQCNS[$i],
+                $this->posts[$i]->hub_id,
+                $messageId
+            );
+            $this->assertSame(null, $response);
+        }
+    }
+
+    /**
+     * メッセージID未定義
+     *
+     * @return void
+     */
+    public function testMessageIdUndefined(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    model: ThreadsConst::MODEL_FQCNS[$i],
+                    threadId: $this->posts[$i]->hub_id
+                ),
+                TypeError::class
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Repositories/ThreadRepository/FindTest.php
+++ b/tests/Unit/app/Repositories/ThreadRepository/FindTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\ThreadRepository;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Repositories\ThreadRepository;
+use Error;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\ThreadsTrait;
+use Tests\Support\PostTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class FindTest extends TestCase implements AssertSameInterface
+{
+    use PostTestTrait,
+        RefreshDatabase,
+        ThreadsTrait;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->postSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new ThreadRepository, 'find'];
+    }
+
+    /**
+     * 期待する書き込みのデータを取得する
+     *
+     * @param array $args ['hubId', 'userId', 'messageId', 'message']の要素が必要
+     * @return array
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected[ThreadsConst::HUB_ID] = $args['hubId'] . '';
+        $expected[ThreadsConst::USER_ID] = $args['userId'] . '';
+        $expected[ThreadsConst::MESSAGE_ID] = $args['messageId'];
+        $expected[ThreadsConst::MESSAGE] = $args['message'];
+        return $expected;
+    }
+
+    /**
+     * 書き込みが取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatThePostCanBeRetrieved(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $response = ($this->method)(
+                ThreadsConst::MODEL_FQCNS[$i],
+                $this->posts[$i]->hub_id,
+                $this->posts[$i]->message_id
+            )->toArray();
+
+            $this->post = $response;
+            $this->assertSame($this->getKeysExpected(), array_keys($response));
+            $this->assertSame($this->getValuesExpected([
+                'hubId' => $this->posts[$i]->hub_id,
+                'userId' => $this->posts[$i]->user_id,
+                'messageId' => $this->posts[$i]->message_id,
+                'message' => $this->posts[$i]->message
+            ]), $this->getValuesActual());
+        }
+    }
+
+    /**
+     * 存在しないモデルを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAModelThatDoesNotExists(): void
+    {
+        $model = 'not existent model';
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $model,
+                    $this->posts[$i]->hub_id,
+                    $this->posts[$i]->message_id
+                ),
+                Error::class
+            );
+        }
+    }
+
+    /**
+     * モデル未定義
+     *
+     * @return void
+     */
+    public function testModelUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadId: $this->posts[$i]->hub_id,
+                    messageId: $this->posts[$i]->message_id
+                ),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * 存在しないスレッドIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAThreadIdThatDoesNotExists(): void
+    {
+        $threadId = 'not existent thread id';
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $response = ($this->method)(
+                ThreadsConst::MODEL_FQCNS[$i],
+                $threadId,
+                $this->posts[$i]->message_id
+            );
+            $this->assertSame(null, $response);
+        }
+    }
+
+    /**
+     * スレッドID未定義
+     *
+     * @return void
+     */
+    public function testThreadIdUndefined(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    model: ThreadsConst::MODEL_FQCNS[$i],
+                    messageId: $this->posts[$i]->message_id
+                ),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * 存在しないメッセージIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAMessageIdThatDoesNotExists(): void
+    {
+        $messageId = -1;
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $response = ($this->method)(
+                ThreadsConst::MODEL_FQCNS[$i],
+                $this->posts[$i]->hub_id,
+                $messageId
+            );
+            $this->assertSame(null, $response);
+        }
+    }
+
+    /**
+     * メッセージID未定義
+     *
+     * @return void
+     */
+    public function testMessageIdUndefined(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::MODEL_FQCNS); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    model: ThreadsConst::MODEL_FQCNS[$i],
+                    threadId: $this->posts[$i]->hub_id
+                ),
+                TypeError::class
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Repositories/ThreadRepository/FindTest.php
+++ b/tests/Unit/app/Repositories/ThreadRepository/FindTest.php
@@ -36,7 +36,7 @@ class FindTest extends TestCase implements AssertSameInterface
      * 期待する書き込みのデータを取得する
      *
      * @param array $args ['hubId', 'userId', 'messageId', 'message']の要素が必要
-     * @return array
+     * @return array 期待する書き込みのデータ
      */
     public function getValuesExpected(array $args): array
     {

--- a/tests/Unit/app/Services/LikeService/CountLikeTest.php
+++ b/tests/Unit/app/Services/LikeService/CountLikeTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Tests\Unit\app\Services\LikeService;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Models\ThreadModel;
+use App\Models\User;
+use App\Services\LikeService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionClass;
+use Tests\Support\PostTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class CountLikeTest extends TestCase
+{
+    use PostTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var mixed テスト対象メソッドがあるクラスのプライベートなメンバ変数 foreignKey
+     */
+    private mixed $propertyForeignKey;
+
+    /**
+     * @var mixed テスト対象メソッドがあるクラスのプライベートなメンバ変数 postId
+     */
+    private mixed $propertyPostId;
+
+    private LikeService $likeService;
+
+    private User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->postSetUp();
+
+        // メンバ変数に値を代入する
+        $this->likeService = new LikeService;
+        $reflection = new ReflectionClass($this->likeService);
+        $this->propertyForeignKey = $reflection->getProperty('foreignKey');
+        $this->propertyForeignKey->setAccessible(true);
+        $this->propertyPostId = $reflection->getProperty('postId');
+        $this->propertyPostId->setAccessible(true);
+        $this->user = User::factory()->create();
+    }
+
+    /**
+     * 書き込みに指定された範囲内のランダムな数，
+     * いいねをする
+     *
+     * @param ThreadModel $post いいねをする書き込み
+     * @param integer $max いいねをするランダムな範囲の最大数
+     * @param integer $min いいねをするランダムな範囲の最小数
+     * @return integer 指定された書き込みにいいねをした数
+     */
+    private function setLikes(ThreadModel $post, $max = 20, $min = 10): int
+    {
+        $num = random_int($min, $max);
+        foreach (range(1, $num) as $_) {
+            Like::factory()->post($post)->create();
+        }
+        return $num;
+    }
+
+    /**
+     * 書き込みのいいね数を取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatCanGetTheNumberOfLikesForAPost(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+
+            $response = $this->likeService->countLike(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $this->posts[$i]->id
+            );
+            $this->assertSame($likes_num, $response);
+        }
+    }
+
+    /**
+     * いいねをした書き込みに保存されているいいね数を，
+     * 取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatCanGetTheNumberOfLikesDoneToAPostThatHaveLiked(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyForeignKey
+                ->setValue($this->likeService, ThreadsConst::USED_FOREIGN_KEYS[$i]);
+            $this->propertyPostId
+                ->setValue($this->likeService, $this->posts[$i]->id);
+
+            $response = $this->likeService->countLike();
+            $this->assertSame($likes_num, $response);
+        }
+    }
+
+    /**
+     * 存在しない外部キー名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAForeignKeyThatDoesNotExist(): void
+    {
+        $foreignKey = 'not existent foreign key';
+        foreach ($this->posts as $post) {
+            $this->setLikes($post);
+            $this->assertThrows(
+                fn () => $this->likeService->countLike($foreignKey, $post->id),
+                QueryException::class
+            );
+        }
+    }
+
+    /**
+     * 外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefined(): void
+    {
+        foreach ($this->posts as $post) {
+            $this->setLikes($post);
+            $this->assertThrows(
+                fn () => $this->likeService->countLike(postId: $post->id),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * メンバ変数の foreignKey に値が代入された状態で外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefinedWithValueAssignedToMemberVariableForeignKey(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyForeignKey
+                ->setValue($this->likeService, ThreadsConst::USED_FOREIGN_KEYS[$i]);
+
+            $response = $this->likeService->countLike(postId: $this->posts[$i]->id);
+            $this->assertSame($likes_num, $response);
+        }
+    }
+
+    /**
+     * メンバ変数の postId に値が代入された状態で外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefinedWithValueAssignedToMemberVariablePostId(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyPostId
+                ->setValue($this->likeService, $this->posts[$i]->id);
+
+            $this->assertThrows(
+                fn () => $this->likeService->countLike(postId: $this->posts[$i]->id),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * メンバ変数に値が代入された状態で外部キー名未定義
+     *
+     * @return void
+     */
+    public function testForeignKeyUndefinedWithValueAssignedToMemberVariable(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyForeignKey
+                ->setValue($this->likeService, ThreadsConst::USED_FOREIGN_KEYS[$i]);
+            $this->propertyPostId
+                ->setValue($this->likeService, $this->posts[$i]->id);
+
+            $response = $this->likeService->countLike(postId: $this->posts[$i]->id);
+            $this->assertSame($likes_num, $response);
+        }
+    }
+
+    /**
+     * 存在しない書き込みIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAPostIdThatDoesNotExist(): void
+    {
+        $postId = -1;
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->setLikes($this->posts[$i]);
+            $response = $this->likeService->countLike(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $postId
+            );
+            $this->assertSame(0, $response);
+        }
+    }
+
+    /**
+     * 書き込みID未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->setLikes($this->posts[$i]);
+            $this->assertThrows(
+                fn () => $this->likeService->countLike(foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i]),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * メンバ変数の foreignKey に値が代入された状態で書き込みID未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefinedWithValueAssignedToMemberVariableForeignKey(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyForeignKey
+                ->setValue($this->likeService, ThreadsConst::USED_FOREIGN_KEYS[$i]);
+
+            $this->assertThrows(
+                fn () => $this->likeService->countLike(foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i]),
+                TypeError::class
+            );
+        }
+    }
+
+    /**
+     * メンバ変数の postId に値が代入された状態で書き込みID未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefinedWithValueAssignedToMemberVariablePostId(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyPostId
+                ->setValue($this->likeService, $this->posts[$i]->id);
+
+            $response = $this->likeService->countLike(foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i]);
+            $this->assertSame($likes_num, $response);
+        }
+    }
+
+    /**
+     * メンバ変数に値が代入された状態で書き込みID未定義
+     *
+     * @return void
+     */
+    public function testPostIdUndefinedWithValueAssignedToMemberVariable(): void
+    {
+        for ($i = 0; $i < count(ThreadsConst::USED_FOREIGN_KEYS); $i++) {
+            $likes_num = $this->setLikes($this->posts[$i]);
+            $this->propertyForeignKey
+                ->setValue($this->likeService, ThreadsConst::USED_FOREIGN_KEYS[$i]);
+            $this->propertyPostId
+                ->setValue($this->likeService, $this->posts[$i]->id);
+
+            $response = $this->likeService->countLike(foreignKey: ThreadsConst::USED_FOREIGN_KEYS[$i]);
+            $this->assertSame($likes_num, $response);
+        }
+    }
+}

--- a/tests/Unit/app/Services/LikeService/DestroyTest.php
+++ b/tests/Unit/app/Services/LikeService/DestroyTest.php
@@ -206,4 +206,49 @@ class DestroyTest extends TestCase
             ? $this->assertTrue(true)
             : $this->assertTrue(false);
     }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAUserIdThatDoesNotExist(): void
+    {
+        $userId = 'not existent user id';
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->likeService->destroy(
+                    $this->posts[$i]->hub_id,
+                    $this->posts[$i]->message_id,
+                    $userId
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * ユーザID未定義
+     *
+     * @return void
+     */
+    public function testUserIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => $this->likeService->destroy(
+                        threadId: $this->posts[$i]->hub_id,
+                        messageId: $this->posts[$i]->message_id
+                    ),
+                    Error::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
 }

--- a/tests/Unit/app/Services/LikeService/DestroyTest.php
+++ b/tests/Unit/app/Services/LikeService/DestroyTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit\app\Services\LikeService;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Services\LikeService;
+use ErrorException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\LikeTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class DestroyTest extends TestCase
+{
+    use LikeTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->likeSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new LikeService, 'destroy'];
+    }
+
+    /**
+     * 対応するいいねを取得する
+     *
+     * @param string|null $foreignKey 書き込みを保存しているテーブルの外部キー
+     * @param integer $postId 書き込みのID
+     * @param string $userId いいねをしたユーザのID
+     * @return array 書き込みにつけたいいねのデータ
+     */
+    private function getLike(
+        string | null $foreignKey,
+        int $postId,
+        string $userId
+    ): array {
+        $where = [];
+        is_null($foreignKey) ?: $where[] = [$foreignKey, $postId];
+        $where[] = ['user_id', $userId];
+
+        return Like::where($where)->get()->toArray();
+    }
+
+    /**
+     * likesテーブルの全データを取得する
+     *
+     * @return array likesテーブルの全データ
+     */
+    private function getAllLike(): array
+    {
+        return Like::get()->toArray();
+    }
+
+    /**
+     * 書き込みのいいねが削除されることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatThePostLikesWillBeDeleted(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                ($this->method)(
+                    $this->posts[$i]->hub_id,
+                    $this->posts[$i]->message_id,
+                    $this->likes[$i][$j]->user_id
+                );
+                $this->assertSame(
+                    [],
+                    $this->getLike(
+                        ThreadsConst::USED_FOREIGN_KEYS[$i],
+                        $this->posts[$i]->id,
+                        $this->likes[$i][$j]->user_id
+                    )
+                );
+            }
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 存在しないスレッドIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAThreadIdThatDoesNotExist(): void
+    {
+        $threadId = 'not existent foreign key';
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        $threadId,
+                        $this->posts[$i]->id,
+                        $this->likes[$i][$j]->user_id
+                    ),
+                    ErrorException::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * スレッドID未定義
+     *
+     * @return void
+     */
+    public function testThreadIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        messageId: $this->posts[$i]->id,
+                        userId: $this->likes[$i][$j]->user_id
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * 存在しないメッセージIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAMessageIdThatDoesNotExist(): void
+    {
+        $messageId = -1;
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        $this->posts[$i]->hub_id,
+                        $messageId,
+                        $this->likes[$i][$j]->user_id
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+
+    /**
+     * メッセージID未定義
+     *
+     * @return void
+     */
+    public function testMessageIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->likes); $i++) {
+            for ($j = 0; $j < count($this->likes[$i]); $j++) {
+                $this->assertThrows(
+                    fn () => ($this->method)(
+                        threadId: $this->posts[$i]->hub_id,
+                        userId: $this->likes[$i][$j]->user_id
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        [] !== $this->getAllLike()
+            ? $this->assertTrue(true)
+            : $this->assertTrue(false);
+    }
+}

--- a/tests/Unit/app/Services/LikeService/DestroyTest.php
+++ b/tests/Unit/app/Services/LikeService/DestroyTest.php
@@ -34,8 +34,7 @@ class DestroyTest extends TestCase
     {
         parent::setUp();
         $this->likeSetUp();
-
-        // メンバ変数に値を代入する
+        
         // メンバ変数に値を代入する
         $this->likeService = new LikeService;
         $reflection = new ReflectionClass($this->likeService);

--- a/tests/Unit/app/Services/LikeService/StoreTest.php
+++ b/tests/Unit/app/Services/LikeService/StoreTest.php
@@ -170,7 +170,7 @@ class StoreTest extends TestCase implements AssertSameInterface
     }
 
     /**
-     * 存在しない外部キー名を引数とする
+     * 存在しないスレッドIDを引数とする
      *
      * @return void
      */

--- a/tests/Unit/app/Services/LikeService/StoreTest.php
+++ b/tests/Unit/app/Services/LikeService/StoreTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Unit\app\Services\LikeService;
+
+use App\Consts\Tables\LikeConst;
+use App\Consts\Tables\ThreadsConst;
+use App\Models\Like;
+use App\Models\User;
+use App\Services\LikeService;
+use ErrorException;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\LikeTrait;
+use Tests\Support\PostTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class StoreTest extends TestCase implements AssertSameInterface
+{
+    use LikeTrait,
+        PostTestTrait,
+        RefreshDatabase;
+
+    private User $user;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->postSetUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+        $this->method = [new LikeService, 'store'];
+    }
+
+    /**
+     * likesテーブルの期待するデータを取得する
+     *
+     * @param array $args ['外部キー名' => 書き込みのID, 'userId'] が必要
+     * @return array likesテーブルの期待するデータ
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        foreach (ThreadsConst::USED_FOREIGN_KEYS as $foreignKey) {
+            $expected[$foreignKey] = $args[$foreignKey] ?? null;
+        }
+        $expected[LikeConst::USER_ID] = $args['userId'] . '';
+        return $expected;
+    }
+
+    /**
+     * 対応するいいねを取得する
+     *
+     * @param string|null $foreignKey 書き込みを保存しているテーブルの外部キー
+     * @param integer $postId 書き込みのID
+     * @param string $userId いいねをしたユーザのID
+     * @return array 書き込みにつけたいいねのデータ
+     */
+    private function getLike(string | null $foreignKey, int $postId, string $userId): array
+    {
+        $where = [];
+        is_null($foreignKey) ?: $where[] = [$foreignKey, $postId];
+        $where[] = ['user_id', $userId];
+
+        return Like::where($where)->first()->toArray();
+    }
+
+    /**
+     * likesテーブルの全データを取得する
+     *
+     * @return array likesテーブルの全データ
+     */
+    private function getAllLike(): array
+    {
+        return Like::get()->toArray();
+    }
+
+    /**
+     * 投稿にいいねができることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatACanLikeThePost(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            ($this->method)(
+                $this->posts[$i]->hub_id,
+                $this->posts[$i]->message_id,
+                $this->user->id
+            );
+
+            $this->like = $this->getLike(
+                ThreadsConst::USED_FOREIGN_KEYS[$i],
+                $this->posts[$i]->id,
+                $this->user->id
+            );
+            $this->assertSame($this->getKeysExpected(), array_keys($this->like));
+            $this->assertSame($this->getValuesExpected([
+                ThreadsConst::USED_FOREIGN_KEYS[$i] => $this->posts[$i]->id,
+                'userId' => $this->user->id
+            ]), $this->getValuesActual());
+        }
+    }
+
+    /**
+     * 同じ書き込みに複数のいいねができることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatACanHaveMultipleLikesOnTheSamePost(): void
+    {
+        $users = [];
+        foreach (range(1, 10) as $_) {
+            $users[] = User::factory()->create();
+        }
+
+        for ($i = 0; $i < count($this->posts); $i++) {
+            foreach ($users as $user) {
+                ($this->method)(
+                    $this->posts[$i]->hub_id,
+                    $this->posts[$i]->message_id,
+                    $user->id
+                );
+            }
+
+            foreach ($users as $user) {
+                $this->like = $this->getLike(
+                    ThreadsConst::USED_FOREIGN_KEYS[$i],
+                    $this->posts[$i]->id,
+                    $user->id
+                );
+                $this->assertSame($this->getKeysExpected(), array_keys($this->like));
+                $this->assertSame($this->getValuesExpected([
+                    ThreadsConst::USED_FOREIGN_KEYS[$i] => $this->posts[$i]->id,
+                    'userId' => $user->id
+                ]), $this->getValuesActual());
+            }
+        }
+    }
+
+    /**
+     * 存在しない外部キー名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAThreadIdThatDoesNotExist(): void
+    {
+        $threadId = 'not existent thread id';
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $threadId,
+                    $this->posts[$i]->message_id,
+                    $this->user->id
+                ),
+                ErrorException::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * スレッドID未定義
+     *
+     * @return void
+     */
+    public function testThreadIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    messageId: $this->posts[$i]->message_id,
+                    userId: $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 存在しないメッセージIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAMessageIdThatDoesNotExist(): void
+    {
+        $messageId = -1;
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $this->posts[$i]->hub_id,
+                    $messageId,
+                    $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * メッセージID未定義
+     *
+     * @return void
+     */
+    public function testMessageIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadId: $this->posts[$i]->hub_id,
+                    userId: $this->user->id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsAUserIdThatDoesNotExist(): void
+    {
+        $userId = 'not existent user id';
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    $this->posts[$i]->hub_id,
+                    $this->posts[$i]->message_id,
+                    $userId
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+
+    /**
+     * ユーザID未定義
+     *
+     * @return void
+     */
+    public function testUserIdUndefined(): void
+    {
+        for ($i = 0; $i < count($this->posts); $i++) {
+            $this->assertThrows(
+                fn () => ($this->method)(
+                    threadId: $this->posts[$i]->hub_id,
+                    messageId: $this->posts[$i]->message_id
+                ),
+                TypeError::class
+            );
+        }
+        $this->assertSame([], $this->getAllLike());
+    }
+}

--- a/tests/Unit/app/Services/ThreadService/ThreadIdToForeignKeyTest.php
+++ b/tests/Unit/app/Services/ThreadService/ThreadIdToForeignKeyTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\app\Services\ThreadService;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Services\ThreadService;
+use ErrorException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\ThreadTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class ThreadIdToForeignKeyTest extends TestCase
+{
+    use ThreadTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->threadSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new ThreadService, 'threadIdToForeignKey'];
+    }
+
+    /**
+     * スレッドIDから外部キー名を取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheForeignKeyNameCanBeObtainedFromTheThreadId(): void
+    {
+        foreach ($this->threads as $thread) {
+            $response = ($this->method)($thread->id);
+            $model = array_search(
+                $thread->thread_secondary_category->thread_primary_category->name,
+                ThreadsConst::MODEL_TO_CATEGORYS
+            );
+            $foreignKey = ThreadsConst::MODEL_TO_USED_FOREIGN_KEYS[$model];
+            $this->assertSame($foreignKey, $response);
+        }
+    }
+
+    /**
+     * 存在しないスレッドIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsTheThreadIdThatDoesNotExists(): void
+    {
+        $threadId = 'not existent thread id';
+        $this->assertThrows(
+            fn () => ($this->method)($threadId),
+            ErrorException::class
+        );
+    }
+
+    /**
+     * スレッドID未定義
+     *
+     * @return void
+     */
+    public function testThreadIdUndefined(): void
+    {
+        $this->assertThrows(
+            fn () => ($this->method)(),
+            TypeError::class
+        );
+    }
+}

--- a/tests/Unit/app/Services/ThreadService/ThreadIdToModelTest.php
+++ b/tests/Unit/app/Services/ThreadService/ThreadIdToModelTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit\app\Services\ThreadService;
+
+use App\Consts\Tables\ThreadsConst;
+use App\Services\ThreadService;
+use ErrorException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\ThreadTestTrait;
+use Tests\TestCase;
+use TypeError;
+
+class ThreadIdToModelTest extends TestCase
+{
+    use ThreadTestTrait,
+        RefreshDatabase;
+
+    /**
+     * @var array テスト対象のメソッド
+     */
+    private array $method;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->threadSetUp();
+
+        // メンバ変数に値を代入する
+        $this->method = [new ThreadService, 'threadIdToModel'];
+    }
+
+    /**
+     * スレッドIDから外部キー名を取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheForeignKeyNameCanBeObtainedFromTheThreadId(): void
+    {
+        foreach ($this->threads as $thread) {
+            $response = ($this->method)($thread->id);
+            $model = array_search(
+                $thread->thread_secondary_category->thread_primary_category->name,
+                ThreadsConst::MODEL_TO_CATEGORYS
+            );
+            $this->assertSame($model, $response);
+        }
+    }
+
+    /**
+     * 存在しないスレッドIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentIsTheThreadIdThatDoesNotExists(): void
+    {
+        $threadId = 'not existent thread id';
+        $this->assertThrows(
+            fn () => ($this->method)($threadId),
+            ErrorException::class
+        );
+    }
+
+    /**
+     * スレッドID未定義
+     *
+     * @return void
+     */
+    public function testThreadIdUndefined(): void
+    {
+        $this->assertThrows(
+            fn () => ($this->method)(),
+            TypeError::class
+        );
+    }
+}


### PR DESCRIPTION
## 関連

- #245 

## なぜこの変更をするのか

- 1ファイルにまとめるには量が多いため
- 細かく分けたほうが管理・更新がしやすいため

## やったこと

- LikeControllerで使用していたEloquentモデルのクエリを各テーブルごとに分けた，リポジトリクラスを作成
- LikeControllerの ↑ 以外の処理を入れたサービスクラスを作成
- ThreadRepositoryに特定の書き込みを取得するメソッド・そのIDを取得するメソッドを追加
- likesテーブル関連の定数クラスにカラム一覧の配列を追加

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- 単体テスト作成
- 書き込みにいいね・いいねの取り消しができることを確認

## その他

なし