### PR TITLE
Mypage/UserControllerをサービスクラスとリポジトリクラスに分割

### DIFF
--- a/app/Consts/Tables/UserConst.php
+++ b/app/Consts/Tables/UserConst.php
@@ -9,4 +9,40 @@ class UserConst
 
     // 外部キーとして利用されるときのカラム名
     const USED_FOREIGN_KEY = 'user_id';
+
+    // カラム名
+    const ID = 'id';
+    const USER_PAGE_THEME_ID = UserPageThemeConst::USED_FOREIGN_KEY;
+    const _NAME = 'name';
+    const EMAIL = 'email';
+    const EMAIL_VERIFIED_AT = 'email_verified_at';
+    const PASSWORD = 'password';
+    const TWO_FACTOR_SECRET = 'two_factor_secret';
+    const TWO_FACTOR_RECOVERY_CODES = 'two_factor_recovery_codes';
+    const TWO_FACTOR_CONFIRMED_AT = 'two_factor_confirmed_at';
+    const REMEMBER_TOKEN = 'remember_token';
+    const CURRENT_TEAM_ID = 'current_team_id';
+    const PROFILE_PHOTO_PATH = 'profile_photo_path';
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
+    const DELETED_AT = 'deleted_at';
+
+    // カラム一覧
+    const COLUMNS = [
+        self::ID,
+        self::USER_PAGE_THEME_ID,
+        self::_NAME,
+        self::EMAIL,
+        self::EMAIL_VERIFIED_AT,
+        self::PASSWORD,
+        self::TWO_FACTOR_SECRET,
+        self::TWO_FACTOR_RECOVERY_CODES,
+        self::TWO_FACTOR_CONFIRMED_AT,
+        self::REMEMBER_TOKEN,
+        self::CURRENT_TEAM_ID,
+        self::PROFILE_PHOTO_PATH,
+        self::CREATED_AT,
+        self::UPDATED_AT,
+        self::DELETED_AT,
+    ];
 }

--- a/app/Consts/Tables/UserPageThemeConst.php
+++ b/app/Consts/Tables/UserPageThemeConst.php
@@ -9,4 +9,14 @@ class UserPageThemeConst
 
     // 外部キーとして利用されるときのカラム名
     const USED_FOREIGN_KEY = 'user_page_theme_id';
+
+    // php artisan db:seed を実行後に保存されるデータ
+    const DEFAULT = 'default';
+    const DARK = 'dark';
+
+    // 保存されたページテーマ一覧
+    const PAGE_THEMES = [
+        self::DEFAULT,
+        self::DARK,
+    ];
 }

--- a/app/Http/Controllers/MyPage/UserController.php
+++ b/app/Http/Controllers/MyPage/UserController.php
@@ -4,10 +4,18 @@ namespace App\Http\Controllers\MyPage;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Services\UserService;
 use Illuminate\Http\Request;
 
 class UserController extends Controller
 {
+    private UserService $userService;
+
+    public function __construct()
+    {
+        $this->userService = new UserService;
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -66,14 +74,15 @@ class UserController extends Controller
      *
      * @link https://readouble.com/laravel/9.x/ja/queries.html
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
+     * @param \Illuminate\Http\Request $request ['page_theme']の要素が必要
+     * @return void なし
      */
-    public function update(Request $request)
+    public function update(Request $request): void
     {
-        User::where('id', '=', $request->user()->id)->update([
-            'user_page_theme_id' => $request->page_theme
-        ]);
+        $this->userService->updateUserPageTheme(
+            $request->user()->id,
+            $request->page_theme
+        );
     }
 
     /**

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\User;
+
+class UserRepository
+{
+    /**
+     * ユーザページテーマの更新
+     *
+     * @param string $userId 更新するユーザのID
+     * @param integer $userPageTheme 更新するページテーマのID
+     * @return void
+     */
+    public static function updateUserPageTheme(string $userId, int $userPageThemeId): void
+    {
+        User::where('id', '=', $userId)->update([
+            'user_page_theme_id' => $userPageThemeId
+        ]);
+    }
+}

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\UserRepository;
+
+class UserService
+{
+    /**
+     * ユーザページテーマの更新
+     *
+     * @param string $userId 更新するユーザのID
+     * @param integer $userPageTheme 更新するページテーマのID
+     * @return void
+     */
+    public function updateUserPageTheme(string $userId, int $userPageThemeId): void
+    {
+        UserRepository::updateUserPageTheme($userId, $userPageThemeId);
+    }
+}

--- a/tests/Support/AssertSame/Tables/UserTrait.php
+++ b/tests/Support/AssertSame/Tables/UserTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Support\AssertSame\Tables;
+
+use App\Consts\Tables\UserConst;
+use Tests\Support\ArrayToolsTrait;
+
+trait UserTrait
+{
+    use ArrayToolsTrait;
+
+    /**
+     * @var array 実際のusersテーブルのデータ
+     */
+    public array $user;
+
+    /**
+     * usersテーブルすべてのカラム名を期待する値として取得する
+     *
+     * @return array 期待するusersテーブルすべてのカラム名
+     */
+    public function getKeysExpected(): array
+    {
+        return UserConst::COLUMNS;
+    }
+
+    /**
+     * users テーブルの一部のカラムのデータを実際の値として返却する
+     *
+     * @param array|null $args
+     * @return array
+     */
+    public function getValuesActual(array $args = null): array
+    {
+        return $this->getArrayElement($this->user, [
+            UserConst::USER_PAGE_THEME_ID,
+            UserConst::_NAME,
+            UserConst::EMAIL,
+            UserConst::EMAIL_VERIFIED_AT,
+            UserConst::TWO_FACTOR_CONFIRMED_AT,
+            UserConst::CURRENT_TEAM_ID,
+            UserConst::PROFILE_PHOTO_PATH,
+        ]);
+    }
+}

--- a/tests/Support/MakeType.php
+++ b/tests/Support/MakeType.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Support;
+
+class MakeType
+{
+    /**
+     * resourceをのぞいたすべての型を生成する
+     *
+     * @link https://www.php.net/manual/ja/language.types.intro.php
+     *
+     * @return array
+     */
+    public static function all(): array
+    {
+        $types = [];
+        $types['null'] = null;
+        $types['bool'] = random_int(0, 1) === 1 ? true : false;
+        $types['int'] = random_int(PHP_INT_MIN, PHP_INT_MAX);
+        $types['float'] = random_int(PHP_INT_MIN, PHP_INT_MAX) / PHP_INT_MAX * 1.0;
+        $types['string'] = Random::string();
+        $types['array'] = [Random::string()];
+        $types['object'] = new MakeType;
+        $types['callable'] = fn () => null;
+        // $types['resource] =
+        return $types;
+    }
+
+    /**
+     * 指定された型の要素をのぞいた配列を返却する
+     *
+     * @param string|array $ignores 除外する要素のkey
+     * @return array $ignoresの型をのぞいた，すべての型を要素とした配列
+     */
+    public static function ignores(string | array $ignores): array
+    {
+        $types = self::all();
+
+        if (is_string($ignores)) {
+            unset($types[$ignores]);
+        }
+
+        if (is_array($ignores)) {
+            foreach ($ignores as $ignore) {
+                unset($types[$ignore]);
+            }
+        }
+
+        return $types;
+    }
+}

--- a/tests/Support/Request.php
+++ b/tests/Support/Request.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Models\User;
+use Illuminate\Http\Request as HttpRequest;
+
+class Request
+{
+    /**
+     * Requestのインスタンスを作成する
+     *
+     * @param array $query $request->で取得可能にする要素
+     * @param User|null $user $request->user()で取得可能にするユーザ
+     * @return HttpRequest Illuminate\Http\Requestのインスタンス
+     */
+    public function make(array $query = [], User $user = null): HttpRequest
+    {
+        $request = new HttpRequest($query);
+        $user === null ?: $request->setUserResolver(function () use ($user) {
+            return $user;
+        });
+        return $request;
+    }
+}

--- a/tests/Unit/app/Http/Controllers/MyPage/UserController/UpdateTest.php
+++ b/tests/Unit/app/Http/Controllers/MyPage/UserController/UpdateTest.php
@@ -159,7 +159,7 @@ class updateTest extends TestCase implements AssertSameInterface
      *
      * @return void
      */
-    public function test(): void
+    public function testUserUndefined(): void
     {
         foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
             $userPageThemeId = $this->getUserPageThemeId($userPageTheme);

--- a/tests/Unit/app/Http/Controllers/MyPage/UserController/UpdateTest.php
+++ b/tests/Unit/app/Http/Controllers/MyPage/UserController/UpdateTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Unit\app\Http\Controllers\MyPage\UserController;
+
+use App\Consts\Tables\UserConst;
+use App\Consts\Tables\UserPageThemeConst;
+use App\Http\Controllers\MyPage\UserController;
+use App\Models\User;
+use App\Models\UserPageTheme;
+use ErrorException;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\UserTrait;
+use Tests\Support\MakeType;
+use Tests\Support\Request;
+use Tests\TestCase;
+use TypeError;
+
+class updateTest extends TestCase implements AssertSameInterface
+{
+    use RefreshDatabase,
+        UserTrait;
+
+    private Request $request;
+
+    private UserController $userController;
+
+    private User $testUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->request = new Request;
+        $this->userController = new UserController;
+        $testUser = User::factory()->create();
+        $this->testUser = User::find($testUser->id);
+    }
+
+    /**
+     * ユーザテーブルの期待する値を取得する
+     *
+     * @param array $args ['userPageThemeId'] が必要
+     * @return array ユーザテーブルの期待する値
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected[UserConst::USER_PAGE_THEME_ID] = $args['userPageThemeId'];
+        $expected[UserConst::_NAME] = $this->testUser->name;
+        $expected[UserConst::EMAIL] = $this->testUser->email;
+        $expected[UserConst::EMAIL_VERIFIED_AT] = $this->testUser->email_verified_at . '';
+        $expected[UserConst::TWO_FACTOR_CONFIRMED_AT] = $this->testUser->two_factor_confirmed_at;
+        $expected[UserConst::CURRENT_TEAM_ID] = $this->testUser->current_team_id;
+        $expected[UserConst::PROFILE_PHOTO_PATH] = $this->testUser->profile_photo_path;
+        return $expected;
+    }
+
+    /**
+     * ページテーマ名からIDを取得する
+     *
+     * @param string $themeName
+     * @return integer
+     */
+    public function getUserPageThemeId(string $themeName): int
+    {
+        return UserPageTheme::where('theme_name', $themeName)->first()->id;
+    }
+
+    /**
+     * 対応するユーザを取得する
+     *
+     * @param string $id ユーザID
+     * @return array 対応するユーザ
+     */
+    public function getUser(string $id): array
+    {
+        return User::find($id)->toArray();
+    }
+
+    /**
+     * ユーザのページテーマを更新できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheUserPageThemeCanBeUpdated(): void
+    {
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageThemeId = $this->getUserPageThemeId($userPageTheme);
+            $this->userController->update(
+                $this->request->make(
+                    ['page_theme' => $userPageThemeId],
+                    $this->testUser
+                )
+            );
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $userPageThemeId]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しないユーザページテーマIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserPageThemeIdThatDoesNotExists(): void
+    {
+        $userPageThemeId = 0;
+        $this->assertThrows(
+            fn () => $this->userController->update(
+                $this->request->make(
+                    ['page_theme' => $userPageThemeId],
+                    $this->testUser
+                )
+            ),
+            QueryException::class
+        );
+        $this->user = $this->getUser($this->testUser->id);
+        $this->assertSame(
+            $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+            $this->getValuesActual()
+        );
+    }
+
+    /**
+     * ユーザページテーマIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserPageThemeIds(): void
+    {
+        foreach (MakeType::ignores(['bool', 'int', 'float']) as $type) {
+            $this->assertThrows(
+                fn () => $this->userController->update(
+                    $this->request->make(
+                        ['page_theme' => $type],
+                        $this->testUser
+                    )
+                ),
+                TypeError::class
+            );
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * ユーザ未定義
+     *
+     * @return void
+     */
+    public function test(): void
+    {
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageThemeId = $this->getUserPageThemeId($userPageTheme);
+            $this->assertThrows(
+                fn () => $this->userController->update(
+                    $this->request->make(
+                        ['page_theme' => $userPageThemeId],
+                    )
+                ),
+                ErrorException::class
+            );
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                $this->getValuesActual()
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Repositories/UserRepository/UpdateUserPageThemeTest.php
+++ b/tests/Unit/app/Repositories/UserRepository/UpdateUserPageThemeTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\UserRepository;
+
+use App\Consts\Tables\UserConst;
+use App\Consts\Tables\UserPageThemeConst;
+use App\Models\User;
+use App\Models\UserPageTheme;
+use App\Repositories\UserRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\UserTrait;
+use Tests\Support\MakeType;
+use Tests\TestCase;
+use TypeError;
+
+class UpdateUserPageThemeTest extends TestCase implements AssertSameInterface
+{
+    use RefreshDatabase,
+        UserTrait;
+
+    private User $testUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $testUser = User::factory()->create();
+        $this->testUser = User::find($testUser->id);
+    }
+
+    /**
+     * ユーザテーブルの期待する値を取得する
+     *
+     * @param array $args ['userPageThemeId'] が必要
+     * @return array ユーザテーブルの期待する値
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected[UserConst::USER_PAGE_THEME_ID] = $args['userPageThemeId'];
+        $expected[UserConst::_NAME] = $this->testUser->name;
+        $expected[UserConst::EMAIL] = $this->testUser->email;
+        $expected[UserConst::EMAIL_VERIFIED_AT] = $this->testUser->email_verified_at . '';
+        $expected[UserConst::TWO_FACTOR_CONFIRMED_AT] = $this->testUser->two_factor_confirmed_at;
+        $expected[UserConst::CURRENT_TEAM_ID] = $this->testUser->current_team_id;
+        $expected[UserConst::PROFILE_PHOTO_PATH] = $this->testUser->profile_photo_path;
+        return $expected;
+    }
+
+    /**
+     * ページテーマ名からIDを取得する
+     *
+     * @param string $themeName
+     * @return integer
+     */
+    public function getUserPageThemeId(string $themeName): int
+    {
+        return UserPageTheme::where('theme_name', $themeName)->first()->id;
+    }
+
+    /**
+     * 対応するユーザを取得する
+     *
+     * @param string $id ユーザID
+     * @return array 対応するユーザ
+     */
+    public function getUser(string $id): array
+    {
+        return User::find($id)->toArray();
+    }
+
+    /**
+     * ユーザのページテーマを更新できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheUserPageThemeCanBeUpdated(): void
+    {
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageThemeId = $this->getUserPageThemeId($userPageTheme);
+            UserRepository::updateUserPageTheme($this->testUser->id, $userPageThemeId);
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $userPageThemeId]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserIdThatDoesNotExists(): void
+    {
+        $userId = 'not existent user id';
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageTHemeId = $this->getUserPageThemeId($userPageTheme);
+            UserRepository::updateUserPageTheme($userId, $userPageTHemeId);
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * ユーザIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserIds(): void
+    {
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageThemeId = $this->getUserPageThemeId($userPageTheme);
+
+            foreach (MakeType::ignores(['int', 'bool', 'float', 'string']) as $type) {
+                $this->assertThrows(
+                    fn () => UserRepository::updateUserPageTheme(
+                        $type,
+                        $userPageThemeId
+                    ),
+                    TypeError::class
+                );
+
+                $this->user = $this->getUser($this->testUser->id);
+                $this->assertSame(
+                    $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                    $this->getValuesActual()
+                );
+            }
+        }
+    }
+
+
+    /**
+     * 存在しないユーザページテーマIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserPageThemeIdThatDoesNotExists(): void
+    {
+        $userPageThemeId = 0;
+        $this->assertThrows(
+            fn () => UserRepository::updateUserPageTheme($this->testUser->id, $userPageThemeId),
+            QueryException::class
+        );
+        $this->user = $this->getUser($this->testUser->id);
+        $this->assertSame(
+            $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+            $this->getValuesActual()
+        );
+    }
+
+    /**
+     * ユーザページテーマIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserPageThemeIds(): void
+    {
+        foreach (MakeType::ignores(['bool', 'int', 'float']) as $type) {
+            $this->assertThrows(
+                fn () => UserRepository::updateUserPageTheme($this->testUser->id, $type),
+                TypeError::class
+            );
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                $this->getValuesActual()
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Services/UserService/UpdateUserPageThemeTest.php
+++ b/tests/Unit/app/Services/UserService/UpdateUserPageThemeTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit\app\Services\UserService;
+
+use App\Consts\Tables\UserConst;
+use App\Consts\Tables\UserPageThemeConst;
+use App\Models\User;
+use App\Models\UserPageTheme;
+use App\Services\UserService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\UserTrait;
+use Tests\Support\MakeType;
+use Tests\TestCase;
+use TypeError;
+
+class UpdateUserPageThemeTest extends TestCase implements AssertSameInterface
+{
+    use RefreshDatabase,
+        UserTrait;
+
+    private UserService $userService;
+
+    private User $testUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->userService = new UserService;
+        $testUser = User::factory()->create();
+        $this->testUser = User::find($testUser->id);
+    }
+
+    /**
+     * ユーザテーブルの期待する値を取得する
+     *
+     * @param array $args ['userPageThemeId'] が必要
+     * @return array ユーザテーブルの期待する値
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected[UserConst::USER_PAGE_THEME_ID] = $args['userPageThemeId'];
+        $expected[UserConst::_NAME] = $this->testUser->name;
+        $expected[UserConst::EMAIL] = $this->testUser->email;
+        $expected[UserConst::EMAIL_VERIFIED_AT] = $this->testUser->email_verified_at . '';
+        $expected[UserConst::TWO_FACTOR_CONFIRMED_AT] = $this->testUser->two_factor_confirmed_at;
+        $expected[UserConst::CURRENT_TEAM_ID] = $this->testUser->current_team_id;
+        $expected[UserConst::PROFILE_PHOTO_PATH] = $this->testUser->profile_photo_path;
+        return $expected;
+    }
+
+    /**
+     * ページテーマ名からIDを取得する
+     *
+     * @param string $themeName
+     * @return integer
+     */
+    public function getUserPageThemeId(string $themeName): int
+    {
+        return UserPageTheme::where('theme_name', $themeName)->first()->id;
+    }
+
+    /**
+     * 対応するユーザを取得する
+     *
+     * @param string $id ユーザID
+     * @return array 対応するユーザ
+     */
+    public function getUser(string $id): array
+    {
+        return User::find($id)->toArray();
+    }
+
+    /**
+     * ユーザのページテーマを更新できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatTheUserPageThemeCanBeUpdated(): void
+    {
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageThemeId = $this->getUserPageThemeId($userPageTheme);
+            $this->userService->updateUserPageTheme($this->testUser->id, $userPageThemeId);
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $userPageThemeId]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserIdThatDoesNotExists(): void
+    {
+        $userId = 'not existent user id';
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageTHemeId = $this->getUserPageThemeId($userPageTheme);
+            $this->userService->updateUserPageTheme($userId, $userPageTHemeId);
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * ユーザIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserIds(): void
+    {
+        foreach (UserPageThemeConst::PAGE_THEMES as $userPageTheme) {
+            $userPageThemeId = $this->getUserPageThemeId($userPageTheme);
+
+            foreach (MakeType::ignores(['int', 'bool', 'float', 'string']) as $type) {
+                $this->assertThrows(
+                    fn () => $this->userService->updateUserPageTheme(
+                        $type,
+                        $userPageThemeId
+                    ),
+                    TypeError::class
+                );
+
+                $this->user = $this->getUser($this->testUser->id);
+                $this->assertSame(
+                    $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                    $this->getValuesActual()
+                );
+            }
+        }
+    }
+
+
+    /**
+     * 存在しないユーザページテーマIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserPageThemeIdThatDoesNotExists(): void
+    {
+        $userPageThemeId = 0;
+        $this->assertThrows(
+            fn () => $this->userService->updateUserPageTheme($this->testUser->id, $userPageThemeId),
+            QueryException::class
+        );
+        $this->user = $this->getUser($this->testUser->id);
+        $this->assertSame(
+            $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+            $this->getValuesActual()
+        );
+    }
+
+    /**
+     * ユーザページテーマIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserPageThemeIds(): void
+    {
+        foreach (MakeType::ignores(['bool', 'int', 'float']) as $type) {
+            $this->assertThrows(
+                fn () => $this->userService->updateUserPageTheme($this->testUser->id, $type),
+                TypeError::class
+            );
+
+            $this->user = $this->getUser($this->testUser->id);
+            $this->assertSame(
+                $this->getValuesExpected(['userPageThemeId' => $this->testUser->user_page_theme_id]),
+                $this->getValuesActual()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- サービスクラスとリポジトリクラスに分けたほうが管理・更新がしやすいため

## やったこと

- `users` テーブル関連の定数クラスにテーブルのカラム名一覧を追加
- `user_page_themes` テーブル関連の定数クラスに初期データの情報を追加（`php artisan db:seed` で挿入されるデータ）
- `MyPage/UserController` で使用していたEloquentモデルのクエリを入れた `users` テーブルのリポジトリクラスを作成
- 変更前の `MyPage/UserController` と同じ動作となるようにリポジトリクラスを呼び出すサービスクラスを作成 

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- テストの作成
- ページテーマが変更されることを確認

## その他

なし