### PR TITLE
機能テスト，laravelフォルダ内のネームスペースがフォルダ名と異なっているのを修正

### DIFF
--- a/tests/Feature/laravel/ApiTokenPermissionsTest.php
+++ b/tests/Feature/laravel/ApiTokenPermissionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/AuthenticationTest.php
+++ b/tests/Feature/laravel/AuthenticationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use App\Providers\RouteServiceProvider;

--- a/tests/Feature/laravel/BrowserSessionsTest.php
+++ b/tests/Feature/laravel/BrowserSessionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/CreateApiTokenTest.php
+++ b/tests/Feature/laravel/CreateApiTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/DeleteAccountTest.php
+++ b/tests/Feature/laravel/DeleteAccountTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/DeleteApiTokenTest.php
+++ b/tests/Feature/laravel/DeleteApiTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/EmailVerificationTest.php
+++ b/tests/Feature/laravel/EmailVerificationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use App\Providers\RouteServiceProvider;

--- a/tests/Feature/laravel/PasswordConfirmationTest.php
+++ b/tests/Feature/laravel/PasswordConfirmationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/PasswordResetTest.php
+++ b/tests/Feature/laravel/PasswordResetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;

--- a/tests/Feature/laravel/ProfileInformationTest.php
+++ b/tests/Feature/laravel/ProfileInformationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/RegistrationTest.php
+++ b/tests/Feature/laravel/RegistrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/TwoFactorAuthenticationSettingsTest.php
+++ b/tests/Feature/laravel/TwoFactorAuthenticationSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/laravel/UpdatePasswordTest.php
+++ b/tests/Feature/laravel/UpdatePasswordTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\_laravel;
+namespace Tests\Feature\laravel;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- ファイルまでのパスとネームスペースが異なっていたため

## やったこと

- tests/Feature/laravel フォルダ内のネームスペースを `Tests/Feature/_laravel` -> `Tests\Feature/laravel` に変更

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- 変更したファイルのテストが `php artisan test` で実行されることを確認

## その他

なし