### PR TITLE
Report/FormContactAdministratorControllerをサービスクラスとリポジトリクラスに分割

### DIFF
--- a/app/Consts/TableConst.php
+++ b/app/Consts/TableConst.php
@@ -6,6 +6,7 @@ use App\Consts\Tables\AccessLogConst;
 use App\Consts\Tables\ClubThreadConst;
 use App\Consts\Tables\CollegeYearThreadConst;
 use App\Consts\Tables\ContactAdministratorConst;
+use App\Consts\Tables\ContactTypeConst;
 use App\Consts\Tables\DepartmentThreadConst;
 use App\Consts\Tables\FailedJobConst;
 use App\Consts\Tables\HubConst;
@@ -29,6 +30,7 @@ class TableConst
         ClubThreadConst::NAME,
         CollegeYearThreadConst::NAME,
         ContactAdministratorConst::NAME,
+        ContactTypeConst::NAME,
         DepartmentThreadConst::NAME,
         FailedJobConst::NAME,
         HubConst::NAME,
@@ -51,6 +53,7 @@ class TableConst
         ClubThreadConst::USED_FOREIGN_KEY,
         CollegeYearThreadConst::USED_FOREIGN_KEY,
         ContactAdministratorConst::USED_FOREIGN_KEY,
+        ContactTypeConst::USED_FOREIGN_KEY,
         DepartmentThreadConst::USED_FOREIGN_KEY,
         FailedJobConst::USED_FOREIGN_KEY,
         HubConst::USED_FOREIGN_KEY,

--- a/app/Consts/Tables/ContactAdministratorConst.php
+++ b/app/Consts/Tables/ContactAdministratorConst.php
@@ -12,8 +12,8 @@ class ContactAdministratorConst
 
     // カラム名
     const ID = 'id';
+    const CONTACT_TYPE_ID = ContactTypeConst::USED_FOREIGN_KEY;
     const USER_ID = UserConst::USED_FOREIGN_KEY;
-    const TYPE = 'type';
     const MESSAGE = 'message';
     const CREATED_AT = 'created_at';
     const UPDATED_AT = 'updated_at';
@@ -21,8 +21,8 @@ class ContactAdministratorConst
     // カラム一覧
     const COLUMNS = [
         self::ID,
+        self::CONTACT_TYPE_ID,
         self::USER_ID,
-        self::TYPE,
         self::MESSAGE,
         self::CREATED_AT,
         self::UPDATED_AT,

--- a/app/Consts/Tables/ContactAdministratorConst.php
+++ b/app/Consts/Tables/ContactAdministratorConst.php
@@ -9,4 +9,22 @@ class ContactAdministratorConst
 
     // 外部キーとして利用されるときのカラム名
     const USED_FOREIGN_KEY = 'contact_administrator_id';
+
+    // カラム名
+    const ID = 'id';
+    const USER_ID = UserConst::USED_FOREIGN_KEY;
+    const TYPE = 'type';
+    const MESSAGE = 'message';
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
+
+    // カラム一覧
+    const COLUMNS = [
+        self::ID,
+        self::USER_ID,
+        self::TYPE,
+        self::MESSAGE,
+        self::CREATED_AT,
+        self::UPDATED_AT,
+    ];
 }

--- a/app/Consts/Tables/ContactTypeConst.php
+++ b/app/Consts/Tables/ContactTypeConst.php
@@ -9,4 +9,22 @@ class ContactTypeConst
 
     // 外部キーとして使用されるときのカラム名
     const USED_FOREIGN_KEY = 'contact_type_id';
+
+    // php artisan db:seed を実行後に保存されるデータ
+    const OFFENSIVE_CONTENT = '不快なコンテンツ';
+    const HARASSMENT_BULLYING = '嫌がらせ，いじめ';
+    const INFRINGEMENT_OF_RIGHTS = '権利の侵害';
+    const SPAM_OR_MISLEADING_CONTENT = 'スパムまたは誤解を招く内容';
+    const BUGS_VULNERABILITIES = '掲示板サイトのバグ・脆弱性';
+    const OTHER = 'その他';
+
+    // 保存された報告・問い合わせのタイプ
+    const CONTACT_TYPES = [
+        self::OFFENSIVE_CONTENT,
+        self::HARASSMENT_BULLYING,
+        self::INFRINGEMENT_OF_RIGHTS,
+        self::SPAM_OR_MISLEADING_CONTENT,
+        self::BUGS_VULNERABILITIES,
+        self::OTHER,
+    ];
 }

--- a/app/Consts/Tables/ContactTypeConst.php
+++ b/app/Consts/Tables/ContactTypeConst.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Consts\Tables;
+
+class ContactTypeConst
+{
+    // テーブル名
+    const NAME = 'contact_types';
+
+    // 外部キーとして使用されるときのカラム名
+    const USED_FOREIGN_KEY = 'contact_type_id';
+}

--- a/app/Http/Controllers/Report/FormContactAdministratorController.php
+++ b/app/Http/Controllers/Report/FormContactAdministratorController.php
@@ -5,10 +5,18 @@ namespace App\Http\Controllers\Report;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Report\FormContactAdministratorRequest;
 use App\Models\ContactAdministrator;
+use App\Services\ContactAdministratorService;
 use Illuminate\Http\Request;
 
 class FormContactAdministratorController extends Controller
 {
+    private ContactAdministratorService $contactAdministratorService;
+
+    public function __construct()
+    {
+        $this->contactAdministratorService = new ContactAdministratorService;
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -43,11 +51,11 @@ class FormContactAdministratorController extends Controller
      */
     public function store(FormContactAdministratorRequest $request)
     {
-        ContactAdministrator::create([
-            'user_id' => $request->user()->id,
-            'type' => $request->radio_1,
-            'message' => $request->report_form_textarea
-        ]);
+        $this->contactAdministratorService->store(
+            $request->radio_1,
+            $request->user()->id,
+            $request->report_form_textarea
+        );
     }
 
     /**

--- a/app/Http/Requests/Report/FormContactAdministratorRequest.php
+++ b/app/Http/Requests/Report/FormContactAdministratorRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Report;
 
+use App\Consts\Tables\ContactTypeConst;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -30,7 +31,7 @@ class FormContactAdministratorRequest extends FormRequest
     public function rules()
     {
         return [
-            'radio_1' => 'required',
+            'radio_1' => 'required | exists:' . ContactTypeConst::NAME . ',name',
             'report_form_textarea' => 'required | max:15000'
         ];
     }
@@ -46,6 +47,7 @@ class FormContactAdministratorRequest extends FormRequest
     {
         return [
             'radio_1.required' => 'どのような内容かを選択して下さい',
+            'radio_1.exists' => '選択された値は有効ではありません',
             'report_form_textarea.required' => '詳しい内容を入力して下さい',
             'report_form_textarea.max' => '15000文字以内で入力して下さい'
         ];

--- a/app/Models/ContactType.php
+++ b/app/Models/ContactType.php
@@ -5,10 +5,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class ContactAdministrator extends Model
+class ContactType extends Model
 {
-    use HasFactory;
-    use SerializeDate;
+    use HasFactory,
+        SerializeDate;
 
     /**
      * 接続するデータベース
@@ -27,7 +27,7 @@ class ContactAdministrator extends Model
      *
      * @var string
      */
-    protected $table = 'contact_administrators';
+    protected $table = 'contact_types';
 
     /**
      * マスアサインメント可能な属性
@@ -39,9 +39,7 @@ class ContactAdministrator extends Model
      * @var string[]
      */
     protected $fillable = [
-        'contact_type_id',
-        'user_id',
-        'message',
+        'name',
     ];
 
     /**
@@ -57,24 +55,13 @@ class ContactAdministrator extends Model
     ];
 
     /**
-     * contact_administrator を所有する contact_type を取得する
-     * 多：1
+     * contact_type に関連する contact_administrator を取得する
+     * 1：多
      *
      * @return void
      */
-    public function contact_type()
+    public function contact_administrators()
     {
-        return $this->belongsTo(ContactType::class);
-    }
-
-    /**
-     * contact administrator を所有する user を取得します．
-     * 多：1
-     *
-     * @link https://readouble.com/laravel/9.x/ja/eloquent-relationships.html
-     */
-    public function user()
-    {
-        return $this->belongsTo(User::class);
+        return $this->hasMany(ContactAdministrator::class);
     }
 }

--- a/app/Repositories/ContactAdministratorRepository.php
+++ b/app/Repositories/ContactAdministratorRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\ContactAdministrator;
+
+class ContactAdministratorRepository
+{
+    /**
+     * 運営への報告・問い合わせを保存する
+     *
+     * @param string $contactTypeId 報告・問い合わせのタイプ
+     * @param string $userId 報告・問い合わせを行うユーザ
+     * @param string $message 報告・問い合わせの詳細な内容
+     * @return void なし
+     */
+    public static function store(string $contactTypeId, string $userId, string $message): void
+    {
+        ContactAdministrator::create([
+            'contact_type_id' => $contactTypeId,
+            'user_id' => $userId,
+            'message' => $message
+        ]);
+    }
+}

--- a/app/Repositories/ContactTypeRepository.php
+++ b/app/Repositories/ContactTypeRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\ContactType;
+
+class ContactTypeRepository
+{
+    /**
+     * お問い合わせの種類名からそのIDを取得する
+     *
+     * @param string $name お問い合わせの種類名
+     * @return integer お問い合わせの種類ID
+     */
+    public static function getIdByName(string $name): int
+    {
+        return ContactType::where('name', $name)->first()->id;
+    }
+}

--- a/app/Services/ContactAdministratorService.php
+++ b/app/Services/ContactAdministratorService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\ContactAdministratorRepository;
+use App\Repositories\ContactTypeRepository;
+
+class ContactAdministratorService
+{
+    /**
+     * ユーザからの報告・問い合わせを保存する
+     *
+     * @param string $contactTypeName 報告・問い合わせの種類
+     * @param string $userId 報告・問い合わせを行ったユーザ
+     * @param string $message 詳細な内容
+     * @return void
+     */
+    public function store(string $contactTypeName, string $userId, string $message): void
+    {
+        ContactAdministratorRepository::store(
+            ContactTypeRepository::getIdByName($contactTypeName),
+            $userId,
+            $message
+        );
+    }
+}

--- a/database/migrations/2023_02_21_145110_create_contact_types_table.php
+++ b/database/migrations/2023_02_21_145110_create_contact_types_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * `php artisan migrate` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('contact_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * `php artisan migrate:rollback` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('contact_type');
+    }
+};

--- a/database/migrations/2023_02_21_145244_drop_column_type_to_contact_administrators_table.php
+++ b/database/migrations/2023_02_21_145244_drop_column_type_to_contact_administrators_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * `php artisan migrate` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+    }
+
+    /**
+     * `php artisan migrate:rollback` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->string('type')->after('message');
+        });
+    }
+};

--- a/database/migrations/2023_02_21_145402_add_column_contact_type_id_to_contact_administrators_table.php
+++ b/database/migrations/2023_02_21_145402_add_column_contact_type_id_to_contact_administrators_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * `php artisan migrate` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->foreignId('contact_type_id')->after('id')->constrained('contact_types');
+        });
+    }
+
+    /**
+     * `php artisan migrate` で実行
+     *
+     * @link https://readouble.com/laravel/9.x/ja/migrations.html
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contact_administrators', function (Blueprint $table) {
+            $table->dropForeign(['contact_type_id']);
+            $table->dropColumn('contact_type_id');
+        });
+    }
+};

--- a/database/seeders/ContactTypeSeeder.php
+++ b/database/seeders/ContactTypeSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ContactType;
+use Illuminate\Database\Seeder;
+
+class ContactTypeSeeder extends Seeder
+{
+    /**
+     * contact_types テーブルの初期データ
+     *
+     * @link https://readouble.com/laravel/9.x/ja/seeding.html
+     *
+     * @return void
+     */
+    public function run()
+    {
+        ContactType::updateOrCreate([
+            'name' => '不快なコンテンツ',
+        ]);
+
+        ContactType::updateOrCreate([
+            'name' => '嫌がらせ，いじめ',
+        ]);
+
+        ContactType::updateOrCreate([
+            'name' => '権利の侵害',
+        ]);
+
+        ContactType::updateOrCreate([
+            'name' => 'スパムまたは誤解を招く内容',
+        ]);
+
+        ContactType::updateOrCreate([
+            'name' => '掲示板サイトのバグ・脆弱性',
+        ]);
+
+        ContactType::updateOrCreate([
+            'name' => 'その他',
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\ThreadPrimaryCategory;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -19,5 +18,6 @@ class DatabaseSeeder extends Seeder
         $this->call(UserPageThemeSeeder::class);
         $this->call(ThreadPrimaryCategorySeeder::class);
         $this->call(ThreadSecondaryCategorySeeder::class);
+        $this->call(ContactTypeSeeder::class);
     }
 }

--- a/tests/Support/AssertSame/Tables/ContactAdministratorTrait.php
+++ b/tests/Support/AssertSame/Tables/ContactAdministratorTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Support\AssertSame\Tables;
+
+use App\Consts\Tables\ContactAdministratorConst;
+use Tests\Support\ArrayToolsTrait;
+
+trait ContactAdministratorTrait
+{
+    use ArrayToolsTrait;
+
+    /**
+     * @var array 期待する contact_administrators テーブルのデータ
+     */
+    public array $contactAdministrator;
+
+    /**
+     * contact_administrators テーブルすべてのカラム名を期待する値として取得する
+     *
+     * @return array contact_administrators テーブルのすべてのカラム名
+     */
+    public function getKeysExpected(): array
+    {
+        return ContactAdministratorConst::COLUMNS;
+    }
+
+    /**
+     * contact_administrators テーブルの一部のカラムのデータを実際の値として取得する
+     *
+     * @param array|null $args 引数は使用しない
+     * @return array contact_administrators テーブルの一部のカラムのデータ
+     */
+    public function getValuesActual(array $args = null): array
+    {
+        return $this->getArrayElement($this->contactAdministrator, [
+            'user_id',
+            'type',
+            'message',
+        ]);
+    }
+}

--- a/tests/Support/AssertSame/Tables/ContactAdministratorTrait.php
+++ b/tests/Support/AssertSame/Tables/ContactAdministratorTrait.php
@@ -33,9 +33,9 @@ trait ContactAdministratorTrait
     public function getValuesActual(array $args = null): array
     {
         return $this->getArrayElement($this->contactAdministrator, [
-            'user_id',
-            'type',
-            'message',
+            ContactAdministratorConst::CONTACT_TYPE_ID,
+            ContactAdministratorConst::USER_ID,
+            ContactAdministratorConst::MESSAGE,
         ]);
     }
 }

--- a/tests/Support/MakeType.php
+++ b/tests/Support/MakeType.php
@@ -48,4 +48,24 @@ class MakeType
 
         return $types;
     }
+
+    /**
+     * string で指定された引数に渡すとエラーが出る型を要素とした配列を返却する
+     *
+     * @return array string で指定された引数に渡すとTypeErrorが発生する型を要素とした配列
+     */
+    public static function ignoreString(): array
+    {
+        return self::ignores(['int', 'bool', 'float', 'string']);
+    }
+
+    /**
+     * int で指定された引数に渡すとエラーが出る型を要素とした配列を返却する
+     *
+     * @return array int で指定された引数に渡すとTypeErrorが発生する型を要素とした配列
+     */
+    public static function ignoreInt(): array
+    {
+        return self::ignores(['bool', 'int', 'float']);
+    }
 }

--- a/tests/Support/Request.php
+++ b/tests/Support/Request.php
@@ -14,9 +14,9 @@ class Request
      * @param User|null $user $request->user()で取得可能にするユーザ
      * @return HttpRequest Illuminate\Http\Requestのインスタンス
      */
-    public function make(array $query = [], User $user = null): HttpRequest
+    public function make(array $query = [], User $user = null, string $httpRequest = HttpRequest::class): HttpRequest
     {
-        $request = new HttpRequest($query);
+        $request = new $httpRequest($query);
         $user === null ?: $request->setUserResolver(function () use ($user) {
             return $user;
         });

--- a/tests/Unit/app/Http/Controllers/Report/FormContactAdministratorController/StoreTest.php
+++ b/tests/Unit/app/Http/Controllers/Report/FormContactAdministratorController/StoreTest.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace Tests\Unit\app\Http\Controllers\Report\FormContactAdministratorController;
+
+use App\Consts\Tables\ContactTypeConst;
+use App\Http\Controllers\Report\FormContactAdministratorController;
+use App\Http\Requests\Report\FormContactAdministratorRequest;
+use App\Models\User;
+use Closure;
+use ErrorException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\Tables\ContactAdministratorTrait;
+use Tests\Support\MakeType;
+use Tests\Support\Random;
+use Tests\Support\Request;
+use Tests\TestCase;
+use Tests\Unit\app\Repositories\ContactAdministratorRepository\StoreTest as RepositoryTest;
+use TypeError;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase,
+        ContactAdministratorTrait;
+
+    private User $user;
+
+    private FormContactAdministratorController $controller;
+
+    private RepositoryTest $repositoryTest;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+        $this->controller = new FormContactAdministratorController();
+        $this->repositoryTest = new RepositoryTest();
+    }
+
+    /**
+     * テスト対象のメソッドを実行する
+     *
+     * @param array $query $request->で取得可能にする要素
+     * @param User|null $user $request->user()で取得可能にするユーザ
+     * @return void
+     */
+    public function execute(array $query, User | null $user): void
+    {
+        $this->controller->store((new Request)->make(
+            $query,
+            $user,
+            FormContactAdministratorRequest::class
+        ));
+    }
+
+    /**
+     * リクエストに渡すデータを取得する
+     *
+     * @param mixed $contactType お問い合わせの種類
+     * @param mixed $message お問い合わせの詳細メッセージ
+     * @return array リクエストに渡すデータ
+     */
+    public function getQuery(mixed $contactType = null, mixed $message = null): array
+    {
+        $query = [];
+        is_null($contactType) ?: $query['radio_1'] = $contactType;
+        is_null($message) ?: $query['report_form_textarea'] = $message;
+        return $query;
+    }
+
+    /**
+     * 引数によりユーザを取得する
+     *
+     * @param boolean $user ユーザを取得するかを指定
+     * @return User|null メンバ変数のユーザ/null
+     */
+    public function getUser(bool $user): User | null
+    {
+        return $user ? $this->user : null;
+    }
+
+    /**
+     * 正常に動作することを期待
+     *
+     * @param mixed $contactType $request->radio_1で取得にする値
+     * @param mixed $message $request->report_form_textareaで取得する値
+     * @param boolean $user $request->user()でユーザを取得できるか否かを指定する
+     * @return void
+     */
+    public function successes(mixed $contactType = null, mixed $message = null, bool $user): void
+    {
+        $this->setUp();
+
+        $this->execute(
+            $this->getQuery($contactType, $message),
+            $this->getUser($user)
+        );
+
+        $this->contactAdministrator = $this->repositoryTest->getContactAdministratorByMessage($message);
+        $this->assertSame(
+            $this->repositoryTest->getValuesExpected([
+                'contactTypeId' => $this->repositoryTest->getContactTypeIdByName($contactType),
+                'userId' => $this->user->id,
+                'message' => $message
+            ]),
+            $this->getValuesActual()
+        );
+    }
+
+    /**
+     * 例外が発生することを期待
+     *
+     * @param mixed $contactType $request->radio_1で取得にする値
+     * @param mixed $message $request->report_form_textareaで取得する値
+     * @param boolean $user $request->user()でユーザを取得できるか否かを指定する
+     * @param string $exception テスト対象のメソッド実行時に期待する例外
+     * @return void
+     */
+    public function exception(mixed $contactType = null, mixed $message = null, bool $user, string $exception): void
+    {
+        $this->setUp();
+
+        $this->assertThrows(
+            fn () => $this->execute(
+                $this->getQuery($contactType, $message),
+                $this->getUser($user)
+            ),
+            $exception
+        );
+
+        $this->assertSame([], $this->repositoryTest->getAllContactAdministrator());
+    }
+
+    /**
+     * @dataProvider dataProvider
+     * @param mixed $contactType $request->radio_1で取得にする値
+     * @param mixed $message $request->report_form_textareaで取得する値
+     * @param boolean $user $request->user()でユーザを取得できるか否かを指定する
+     * @param string|null $exception テスト対象のメソッド実行時に期待する例外
+     * @return void
+     */
+    public function test(mixed $contactType = null, mixed $message = null, bool $user, string $exception = null): void
+    {
+        is_null($exception)
+            ? $this->successes($contactType, $message, $user)
+            : $this->exception($contactType, $message, $user, $exception);
+    }
+
+    /**
+     * データプロバイダ
+     *
+     * @return array
+     */
+    public function dataProvider(): array
+    {
+        $this->createApplication();
+
+        return [
+            ...$this->existsRadio1(),
+            ...$this->notExistsRadio1(),
+            ...$this->variousTypeOfRadio1(),
+            ...$this->userUndefined(),
+            ...$this->variousTypeOfReportFormTextarea(),
+            ...$this->numericReportFormTextarea(),
+            ...$this->lowercaseReportFormTextarea(),
+            ...$this->uppercaseReportFormTextarea(),
+            ...$this->symbolReportFormTextarea(),
+            ...$this->noData(),
+        ];
+    }
+
+    /**
+     * すべてのお問い合わせの種類で繰り返し処理行う
+     *
+     * @param Closure $func 繰り返しで行う処理
+     * @return array
+     */
+    public function loopContactType(Closure $func): array
+    {
+        return $this->loop(ContactTypeConst::CONTACT_TYPES, $func);
+    }
+
+    /**
+     * string で指定された引数に渡すとエラーが出る型を
+     * 要素とした配列で繰り返し処理を行う
+     *
+     * @param Closure $func 繰り返しで行う処理
+     * @return array
+     */
+    public function loopVariousType(Closure $func): array
+    {
+        return $this->loop(MakeType::ignoreString(), $func);
+    }
+
+    /**
+     * 指定された配列で繰り返し処理を行う
+     *
+     * @param mixed $loop 繰り返しを行う配列
+     * @param Closure $func 繰り返し内で行う処理
+     * @return array
+     */
+    public function loop(mixed $loop, Closure $func): array
+    {
+        $response = [];
+        foreach ($loop as $key => $value) {
+            $response = $func($response, $value, $key);
+        }
+        return $response;
+    }
+
+    /**
+     * 引数の文字列を report_form_textarea とする
+     *
+     * @param string $message report_form_textareaとする文字列
+     * @param string $type 連想配列のキー（一部分）
+     * @return array
+     */
+    public function variousStringReportFormTextarea(string $message, string $type): array
+    {
+        return $this->loopContactType(function ($response, $contactType) use ($message, $type) {
+            $response["$contactType を radio_1 とし，すべて $type の文字列を report_form_textarea とする"] = [
+                $contactType, $message, true
+            ];
+            return $response;
+        });
+    }
+
+    /**
+     * 期待する radio_1 の値
+     *
+     * @return array
+     */
+    public function existsRadio1(): array
+    {
+        return $this->loopContactType(function ($response, $contactType) {
+            $response["$contactType を radio_1 の値とする"] = [
+                $contactType, Random::string(), true
+            ];
+            return $response;
+        });
+    }
+
+    /**
+     * 存在しないお問い合わせの種類を radio_1 とする
+     *
+     * @return array
+     */
+    public function notExistsRadio1(): array
+    {
+        $radio_1 = 'not exists contact type name';
+        return ['存在しないお問い合わせの種類を radio_1とする' => [
+            $radio_1, Random::string(), true, ErrorException::class
+        ]];
+    }
+
+    /**
+     * 様々な型の変数を radio_1 とする
+     *
+     * @return array
+     */
+    public function variousTypeOfRadio1(): array
+    {
+        return $this->loopVariousType(function ($response, $value, $key) {
+            $response["$key 型の変数を radio_1 とする"] = [
+                $value, Random::string(), true, TypeError::class
+            ];
+            return $response;
+        });
+    }
+
+    /**
+     * リクエストのユーザ未定義
+     *
+     * @return array
+     */
+    public function userUndefined(): array
+    {
+        return $this->loopContactType(function ($response, $contactType) {
+            $response["$contactType を radio_1 とするが，ユーザが未定義"] = [
+                $contactType, Random::string(), false, ErrorException::class
+            ];
+            return $response;
+        });
+    }
+
+    /**
+     * 様々な型の変数を report_form_textarea とする
+     *
+     * @return array
+     */
+    public function variousTypeOfReportFormTextarea(): array
+    {
+        return $this->loopContactType(function ($_, $contactType) {
+            return $this->loopVariousType(function ($response, $value, $key) use ($contactType) {
+                $response["$key 型の変数を report_form_textarea とする"] = [
+                    $contactType, $value, true, TypeError::class
+                ];
+                return $response;
+            });
+        });
+    }
+
+    /**
+     * すべて数字のメッセージを report_form_textarea とする
+     *
+     * @return array
+     */
+    public function numericReportFormTextarea(): array
+    {
+        return $this->variousStringReportFormTextarea(Random::stringOfNumbers(), '数字');
+    }
+
+    /**
+     * すべて英小文字のメッセージを report_form_textarea とする
+     *
+     * @return array
+     */
+    public function lowercaseReportFormTextarea(): array
+    {
+        return $this->variousStringReportFormTextarea(Random::lowercase(), '英小文字');
+    }
+
+    /**
+     * すべて英大文字のメッセージを report_form_textarea とする
+     *
+     * @return array
+     */
+    public function uppercaseReportFormTextarea(): array
+    {
+        return $this->variousStringReportFormTextarea(Random::uppercase(), '英大文字');
+    }
+
+    /**
+     * すべて記号のメッセージを report_form_textarea とする
+     *
+     * @return array
+     */
+    public function symbolReportFormTextarea(): array
+    {
+        return $this->variousStringReportFormTextarea(Random::symbol(), '記号');
+    }
+
+
+    /**
+     * データなしのリクエスト
+     *
+     * @return array
+     */
+    public function noData(): array
+    {
+        return ['データなしのリクエスト' => [null, null, true, TypeError::class]];
+    }
+}

--- a/tests/Unit/app/Http/Requests/Report/FormContactAdministratorRequestTest.php
+++ b/tests/Unit/app/Http/Requests/Report/FormContactAdministratorRequestTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Unit\app\Http\Requests\Report;
+
+use App\Consts\Tables\ContactTypeConst;
+use App\Http\Requests\Report\FormContactAdministratorRequest;
+use ErrorException;
+use Illuminate\Support\Facades\Validator;
+use stdClass;
+use Tests\Support\Random;
+use Tests\TestCase;
+
+class FormContactAdministratorRequestTest extends TestCase
+{
+    const TYPE = 'radio_1';
+    const TEXT = 'report_form_textarea';
+    const TYPE_REQUIRED = 'どのような内容かを選択して下さい';
+    const TYPE_EXISTS = '選択された値は有効ではありません';
+    const TEXT_REQUIRED = '詳しい内容を入力して下さい';
+    const TEXT_MAX = '15000文字以内で入力して下さい';
+
+    /**
+     * @dataProvider validationDataProvider
+     * @param array $parameters
+     * @param boolean $expected
+     * @param array $messages
+     * @return void
+     */
+    public function test(array $parameters, bool $expected, array $messages = ['', '']): void
+    {
+        $request = new FormContactAdministratorRequest();
+        $validator = Validator::make($parameters, $request->rules(), $request->messages());
+        $errorMessages = json_decode($validator->messages());
+
+        $radio1ErrorMessage = $this->getRadio1ErrorMessage($errorMessages);
+        $reportFormTextareaErrorMessage = $this->getReportFormTextareaErrorMessage($errorMessages);
+
+        $this->assertSame($expected, $validator->passes());
+        $this->assertSame($radio1ErrorMessage, $messages[0]);
+        $this->assertSame($reportFormTextareaErrorMessage, $messages[1]);
+    }
+
+    /**
+     * radio_1 に対するエラーメッセージを返却する
+     * なければから文字を返却
+     *
+     * @param stdClass|array $errorMessages バリデータのからエラーメッセージをjson_decode
+     * @return string radio_1 に対するエラーメッセージ
+     */
+    public function getRadio1ErrorMessage(stdClass | array $errorMessages): string
+    {
+        try {
+            return $errorMessages->radio_1[0];
+        } catch (ErrorException $e) {
+            return '';
+        }
+    }
+
+    /**
+     * report_form_textarea に対するエラーメッセージを返却する
+     * なければから文字を返却
+     *
+     * @param stdClass|array $errorMessages バリデータからのエラーメッセージをjson_decode
+     * @return string report_form_textarea に対するエラーメッセージ
+     */
+    public function getReportFormTextareaErrorMessage(stdClass | array $errorMessages): string
+    {
+        try {
+            return $errorMessages->report_form_textarea[0];
+        } catch (ErrorException $e) {
+            return '';
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function validationDataProvider(): array
+    {
+        return [
+            ...$this->expectData(),
+            ...$this->noData(),
+            ...$this->noRadio1(),
+            ...$this->existsRadio1(),
+            ...$this->notExistsRadio1(),
+            ...$this->noReportFormTextarea(),
+            ...$this->maxReportFormTextarea(),
+            ...$this->overReportFormTextarea(),
+        ];
+    }
+
+    public function expectData(): array
+    {
+        return [
+            '正しい入力' => [
+                [
+                    self::TYPE => ContactTypeConst::CONTACT_TYPES[0],
+                    self::TEXT => Random::string(),
+                ],
+                true
+            ],
+        ];
+    }
+
+    /**
+     * radio_1, report_form_textarea ともにデータなし
+     *
+     * @return array
+     */
+    public function noData(): array
+    {
+        return [
+            'radio_1, report_form_textarea ともにデータなし' => [
+                [], false, [self::TYPE_REQUIRED, self::TEXT_REQUIRED],
+            ],
+        ];
+    }
+
+    /**
+     * radio_1 にデータなし
+     *
+     * @return array
+     */
+    public function noRadio1(): array
+    {
+        return [
+            'radio_1 データなし' => [
+                [self::TEXT => Random::string()], false, [self::TYPE_REQUIRED, ''],
+            ],
+        ];
+    }
+
+    /**
+     * contact_types テーブルに存在するデータを radio_1 とする
+     *
+     * @return array
+     */
+    public function existsRadio1(): array
+    {
+        $response = [];
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $response["$contactType を radio_1 の値とする"] = [
+                [self::TYPE => $contactType], false, ['', self::TEXT_REQUIRED],
+            ];
+        }
+        return $response;
+    }
+
+    /**
+     * contact_types テーブルに存在しないデータを radio_1 とする
+     *
+     * @return array
+     */
+    public function notExistsRadio1(): array
+    {
+        return [
+            'contact_types テーブルに存在しないデータを radio_1 とする' => [
+                [self::TYPE => 'not exists contact type name'], false, [self::TYPE_EXISTS, self::TEXT_REQUIRED],
+            ],
+        ];
+    }
+
+    /**
+     * report_form_textarea にデータなし
+     *
+     * @return array
+     */
+    public function noReportFormTextarea(): array
+    {
+        return [
+            'report_form_textarea にデータなし' => [
+                [self::TYPE => ContactTypeConst::CONTACT_TYPES[0]], false, ['', self::TEXT_REQUIRED],
+            ],
+        ];
+    }
+
+    /**
+     * report_form_textarea の最大文字数
+     *
+     * @return array
+     */
+    public function maxReportFormTextarea(): array
+    {
+        return [
+            'report_form_textarea の最大文字数' => [
+                [self::TEXT => Random::string(15000)], false, [self::TYPE_REQUIRED, '']
+            ],
+        ];
+    }
+
+    /**
+     * report_form_textarea の文字数制限を超過
+     *
+     * @return array
+     */
+    public function overReportFormTextarea(): array
+    {
+        return [
+            'report_form_textarea の文字数制限を超過' => [
+                [self::TEXT => Random::string(15001)], false, [self::TYPE_REQUIRED, self::TEXT_MAX]
+            ],
+        ];
+    }
+}

--- a/tests/Unit/app/Repositories/ContactAdministratorRepository/StoreTest.php
+++ b/tests/Unit/app/Repositories/ContactAdministratorRepository/StoreTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\ContactAdministratorRepository;
+
+use App\Consts\Tables\ContactAdministratorConst;
+use App\Consts\Tables\ContactTypeConst;
+use App\Models\ContactAdministrator;
+use App\Models\ContactType;
+use App\Models\User;
+use App\Repositories\ContactAdministratorRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\ContactAdministratorTrait;
+use Tests\Support\MakeType;
+use Tests\Support\Random;
+use Tests\TestCase;
+use TypeError;
+
+class StoreTest extends TestCase implements AssertSameInterface
+{
+    use RefreshDatabase,
+        ContactAdministratorTrait;
+
+    private User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+    }
+
+    /**
+     * contact_administrators テーブルの期待する値を取得する
+     *
+     * @param array $args ['contactTypeId', 'userId', 'message'] の要素が必要
+     * @return array contact_administrators テーブルの期待する値
+     */
+    public function getValuesExpected(array $args): array
+    {
+        $expected = [];
+        $expected[ContactAdministratorConst::CONTACT_TYPE_ID] = $args['contactTypeId'];
+        $expected[ContactAdministratorConst::USER_ID] = $args['userId'] . '';
+        $expected[ContactAdministratorConst::MESSAGE] = $args['message'];
+        return $expected;
+    }
+
+    /**
+     * お問い合わせの種類名からそのIDを取得する
+     *
+     * @param string $name お問い合わせの種類名
+     * @return integer お問い合わせの種類ID
+     */
+    public function getContactTypeIdByName(string $name): int
+    {
+        return ContactType::where('name', $name)->first()->id;
+    }
+
+    /**
+     * 対応する報告を取得する
+     *
+     * @param string $message 報告の詳細メッセージ
+     * @return array 保存された報告
+     */
+    public function getContactAdministratorByMessage(string $message): array
+    {
+        return ContactAdministrator::where('message', $message)->first()->toArray();
+    }
+
+    /**
+     * すべての報告を取得する
+     *
+     * @return array すべての報告
+     */
+    public function getAllContactAdministrator(): array
+    {
+        return ContactAdministrator::get()->toArray();
+    }
+
+    /**
+     * ユーザからの報告が保存できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatReportsFromUsersCanBeSaved(): void
+    {
+        $message = 0;
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            ContactAdministratorRepository::store(
+                $this->getContactTypeIdByName($contactType),
+                $this->user->id,
+                (string) ++$message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage((string) $message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => (string) $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しないお問い合わせの種類を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatContactTypeIdThatDoesNotExists(): void
+    {
+        $contactTypeId = 0;
+        $this->assertThrows(
+            fn () => ContactAdministratorRepository::store(
+                $contactTypeId,
+                $this->user->id,
+                Random::string()
+            ),
+            QueryException::class
+        );
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * お問い合わせ種類のIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsContactTypeIds(): void
+    {
+        foreach (MakeType::ignoreInt() as $type) {
+            $this->assertThrows(
+                fn () => ContactAdministratorRepository::store(
+                    $type,
+                    $this->user->id,
+                    Random::string()
+                )
+            );
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserIdThatDoesNotExists(): void
+    {
+        $userId = 'not existent user id';
+        $message = 0;
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $this->assertThrows(
+                fn () => ContactAdministratorRepository::store(
+                    $this->getContactTypeIdByName($contactType),
+                    $userId,
+                    (string) ++$message
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * ユーザIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserIds(): void
+    {
+        $message = 0;
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            foreach (MakeType::ignoreString() as $type) {
+                $this->assertThrows(
+                    fn () => ContactAdministratorRepository::store(
+                        $this->getContactTypeIdByName($contactType),
+                        $type,
+                        (string) ++$message
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * メッセージとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsMessages(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            foreach (MakeType::ignoreString() as $type) {
+                $this->assertThrows(
+                    fn () => ContactAdministratorRepository::store(
+                        $this->getContactTypeIdByName($contactType),
+                        $this->user->id,
+                        $type
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * すべて数字のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testAllNumericMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::stringOfNumbers();
+            ContactAdministratorRepository::store(
+                $this->getContactTypeIdByName($contactType),
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * すべて英子文字のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testTakeAnAllLowercaseMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::lowercase();
+            ContactAdministratorRepository::store(
+                $this->getContactTypeIdByName($contactType),
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * すべて英大文字のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testTakeAnAllUpperCaseMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::uppercase();
+            ContactAdministratorRepository::store(
+                $this->getContactTypeIdByName($contactType),
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * すべて記号のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testTakeAnAllSymbolMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::symbol();
+            ContactAdministratorRepository::store(
+                $this->getContactTypeIdByName($contactType),
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Repositories/ContactTypeRepository/GetIdByNameTest.php
+++ b/tests/Unit/app/Repositories/ContactTypeRepository/GetIdByNameTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\app\Repositories\ContactTypeRepository;
+
+use App\Consts\Tables\ContactTypeConst;
+use App\Models\ContactType;
+use App\Repositories\ContactTypeRepository;
+use ErrorException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\MakeType;
+use Tests\TestCase;
+use TypeError;
+
+class GetIdByNameTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * お問い合わせの種類IDからその名前を取得する
+     *
+     * @param integer $id お問い合わせの種類id
+     * @return string お問い合わせの種類名
+     */
+    public function getContactTypeNameById(int $id): string
+    {
+        return ContactType::find($id)->name;
+    }
+
+    /**
+     * お問い合わせの種類名からそのIDを取得できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatCanGetThatIdFromTheInquiryTypeName(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $contactTypeId = ContactTypeRepository::getIdByName($contactType);
+            $this->assertSame(
+                $contactType,
+                $this->getContactTypeNameById($contactTypeId)
+            );
+        }
+    }
+
+    /**
+     * 存在しないお問い合わせの種類名を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatContactTypeNameThatDoesNotExists(): void
+    {
+        $contactTypeName = 'not existent contact type name';
+        $this->assertThrows(
+            fn () => ContactTypeRepository::getIdByName($contactTypeName),
+            ErrorException::class
+        );
+    }
+
+    /**
+     * お問い合わせの種類名として様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsContactTypeNames(): void
+    {
+        foreach (MakeType::ignoreString() as $type) {
+            $this->assertThrows(
+                fn () => ContactTypeRepository::getIdByName($type),
+                TypeError::class
+            );
+        }
+    }
+}

--- a/tests/Unit/app/Services/ContactAdministratorService/StoreTest.php
+++ b/tests/Unit/app/Services/ContactAdministratorService/StoreTest.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Tests\Unit\app\Services\ContactAdministratorService;
+
+use App\Consts\Tables\ContactTypeConst;
+use App\Models\User;
+use App\Services\ContactAdministratorService;
+use ErrorException;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AssertSame\AssertSameInterface;
+use Tests\Support\AssertSame\Tables\ContactAdministratorTrait;
+use Tests\Support\MakeType;
+use Tests\Support\Random;
+use Tests\TestCase;
+use Tests\Unit\app\Repositories\ContactAdministratorRepository\StoreTest as RepositoryTest;
+use TypeError;
+
+class StoreTest extends TestCase implements AssertSameInterface
+{
+    use RefreshDatabase,
+        ContactAdministratorTrait;
+
+    private User $user;
+
+    private ContactAdministratorService $contactAdministratorService;
+
+    private RepositoryTest $repositoryTest;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // メンバ変数に値を代入する
+        $this->user = User::factory()->create();
+        $this->contactAdministratorService = new ContactAdministratorService;
+        $this->repositoryTest = new RepositoryTest;
+    }
+
+    /**
+     * contact_administrators テーブルの期待する値を取得する
+     *
+     * @param array $args ['contactTypeId', 'userId', 'message'] の要素が必要
+     * @return array contact_administrators テーブルの期待する値
+     */
+    public function getValuesExpected(array $args): array
+    {
+        return $this->repositoryTest->getValuesExpected($args);
+    }
+
+    /**
+     * お問い合わせの種類名からそのIDを取得する
+     *
+     * @param string $name お問い合わせの種類名
+     * @return integer お問い合わせの種類ID
+     */
+    public function getContactTypeIdByName(string $name): int
+    {
+        return $this->repositoryTest->getContactTypeIdByName($name);
+    }
+
+    /**
+     * 対応する報告を取得する
+     *
+     * @param string $message 報告の詳細メッセージ
+     * @return array 保存された報告
+     */
+    public function getContactAdministratorByMessage(string $message): array
+    {
+        return $this->repositoryTest->getContactAdministratorByMessage($message);
+    }
+
+    /**
+     * すべての報告を取得する
+     *
+     * @return array すべての報告
+     */
+    public function getAllContactAdministrator(): array
+    {
+        return $this->repositoryTest->getAllContactAdministrator();
+    }
+
+    /**
+     * ユーザからの報告が保存できることをアサートする
+     *
+     * @return void
+     */
+    public function testAssertThatReportsFromUsersCanBeSaved(): void
+    {
+        $message = 0;
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $this->contactAdministratorService->store(
+                $contactType,
+                $this->user->id,
+                (string) ++$message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage((string) $message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => (string) $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * 存在しないお問い合わせの種類を引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatContactTypeNameThatDoesNotExists(): void
+    {
+        $contactTypeName = 'not existent contact type name';
+        $this->assertThrows(
+            fn () => $this->contactAdministratorService->store(
+                $contactTypeName,
+                $this->user->id,
+                Random::string()
+            ),
+            ErrorException::class
+        );
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+
+    /**
+     * お問い合わせ種類名として様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsContactTypeNames(): void
+    {
+        foreach (MakeType::ignoreString() as $type) {
+            $this->assertThrows(
+                fn () => $this->contactAdministratorService->store(
+                    $type,
+                    $this->user->id,
+                    Random::string()
+                )
+            );
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * 存在しないユーザIDを引数とする
+     *
+     * @return void
+     */
+    public function testArgumentThatAUserIdThatDoesNotExists(): void
+    {
+        $userId = 'not existent user id';
+        $message = 0;
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $this->assertThrows(
+                fn () => $this->contactAdministratorService->store(
+                    $contactType,
+                    $userId,
+                    (string) ++$message
+                ),
+                QueryException::class
+            );
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * ユーザIDとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsUserIds(): void
+    {
+        $message = 0;
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            foreach (MakeType::ignoreString() as $type) {
+                $this->assertThrows(
+                    fn () => $this->contactAdministratorService->store(
+                        $contactType,
+                        $type,
+                        (string) ++$message
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * メッセージとして様々な型を引数とする
+     *
+     * @return void
+     */
+    public function testVariousTypesOfArgumentsAsMessages(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            foreach (MakeType::ignoreString() as $type) {
+                $this->assertThrows(
+                    fn () => $this->contactAdministratorService->store(
+                        $contactType,
+                        $this->user->id,
+                        $type
+                    ),
+                    TypeError::class
+                );
+            }
+        }
+        $this->assertSame([], $this->getAllContactAdministrator());
+    }
+
+    /**
+     * すべて数字のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testAllNumericMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::stringOfNumbers();
+            $this->contactAdministratorService->store(
+                $contactType,
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * すべて英子文字のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testTakeAnAllLowercaseMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::lowercase();
+            $this->contactAdministratorService->store(
+                $contactType,
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * すべて英大文字のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testTakeAnAllUpperCaseMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::uppercase();
+            $this->contactAdministratorService->store(
+                $contactType,
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+
+    /**
+     * すべて記号のメッセージを引数とする
+     *
+     * @return void
+     */
+    public function testTakeAnAllSymbolMessageAsAnArgument(): void
+    {
+        foreach (ContactTypeConst::CONTACT_TYPES as $contactType) {
+            $message = Random::symbol();
+            $this->contactAdministratorService->store(
+                $contactType,
+                $this->user->id,
+                $message
+            );
+
+            $this->contactAdministrator = $this->getContactAdministratorByMessage($message);
+            $this->assertSame(
+                $this->getValuesExpected([
+                    'contactTypeId' => $this->getContactTypeIdByName($contactType),
+                    'userId' => $this->user->id,
+                    'message' => $message
+                ]),
+                $this->getValuesActual()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 関連

- なし

## なぜこの変更をするのか

- サービスクラスとリポジトリクラスに分けたほうが管理・更新がしやすいため

## やったこと

- `contact_administrators` テーブル関連の定数クラスにカラムの情報を追加
- `contact_administrators` テーブルの `type` を外部のテーブル（`contact_types`）に分割し，外部キーとして利用
- `contact_types` テーブルにお問い合わせ種類のタイプを保存するSeederを作成
- `contact_administrators` テーブル関連のクエリを入れるリポジトリクラスを作成
- `Request/FormContactAdministratorRequest` クラスのバリデーション `radio_1` の値は `contact_types` テーブルの `name` に存在しなければならないというルールを追加
- 変更前の `Report/FormContactAdministratorController` と同じ動作となるようにリポジトリクラスを呼び出すサービスクラスを作成
- `Report/FormContactAdministratorController` ではクエリを実行せずにサービスクラスを呼び出すように変更

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- テストの作成
- ダッシュボードのお問い合わせページから送信したデータがDBに保存されていることを確認

## その他

テーブルを変更しましたので，`php artisan migrate`, `php artisan db:seed` をお願いします