### PR TITLE
welcomeページのタイトルを "hira-chan" に変更

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -18,10 +18,10 @@
 
     <!-- Bootstrap用JavaScript -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
-        crossorigin="anonymous"></script>
+        integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous">
+    </script>
 
-    <title>Laravel</title>
+    <title>{{ config('app.name') }}</title>
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
@@ -31,8 +31,7 @@
 </head>
 
 <body class="antialiased">
-    <div
-        class="relative flex items-top justify-center min-h-screen sm:items-center py-4 sm:pt-0 bg-white">
+    <div class="relative flex items-top justify-center min-h-screen sm:items-center py-4 sm:pt-0 bg-white">
         <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
             <div class="flex justify-center pt-8 sm:justify-start sm:pt-0">
                 <p class="h1">HxS コンピュータ部</p>


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- welcomeページのタイトルがアプリの名前でなく `Laravel` であったため

## やったこと

- welcomeページのタイトルを `hira-chan` に変更

## やらないこと

なし

## できるようになること（ユーザ目線）

- welcomeページもアプリケーション名を見ることができる

## できなくなること（ユーザ目線）

なし

## 動作確認

- welcomeページへアクセスし，タイトルが "hira-chan" になっていることを確認

## その他

なし