### PR TITLE
スレッド取得のAPIで不要な要素を返却しないように修正

### DIFF
--- a/app/Http/Controllers/API/HubController.php
+++ b/app/Http/Controllers/API/HubController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\ThreadResource;
 use App\Services\HubService;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 
 class HubController extends Controller
@@ -19,9 +19,9 @@ class HubController extends Controller
     /**
      * スレッド一覧を表示する
      */
-    public function index(): Collection
+    public function index(): ThreadResource
     {
-        return $this->hubService->index();
+        return new ThreadResource($this->hubService->index());
     }
 
     /**

--- a/app/Http/Resources/ThreadResource.php
+++ b/app/Http/Resources/ThreadResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ThreadResource extends ResourceCollection
+{
+    /**
+     * スレッドの情報を必要最低限の要素に整形し返却する
+     *
+     * @param Request|null $request アクセス時のパラメータなど
+     * @return array<int|string, mixed> スレッドの情報
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'data' => $this->collection->map(function (mixed $v) {
+                return [
+                    'id' => $v['id'],
+                    'name' => $v['name'],
+                    'accessCount' => $v['access_logs_count'],
+                    'primaryCategoryId' => $v['thread_secondary_category']['thread_primary_category_id'],
+                    'secondaryCategoryId' => $v['thread_secondary_category_id'],
+                    'createdAt' => $v['created_at'],
+                ];
+            }),
+        ];
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1374,9 +1374,6 @@ select {
 .overflow-y-auto {
   overflow-y: auto;
 }
-.overflow-y-hidden {
-  overflow-y: hidden;
-}
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1805,9 +1802,6 @@ select {
 }
 .ring-opacity-5 {
   --tw-ring-opacity: 0.05;
-}
-.filter {
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 .transition {
   transition-property: color, background-color, border-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-text-decoration-color, -webkit-backdrop-filter;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -14678,7 +14678,9 @@ var hubIndex = function hubIndex(hubUrl, setThreads) {
     _lib_axios__WEBPACK_IMPORTED_MODULE_1__.axios.get(hubUrl).then(function (response) {
       return response.data;
     }).then(function (data) {
-      setThreads(data);
+      return data.data;
+    }).then(function (threads) {
+      setThreads(threads);
     })["catch"](function (error) {
       return null;
     });
@@ -14889,7 +14891,7 @@ var Tbody = function Tbody(_a) {
   var someThreads = threads.slice(threadNum.row * (threadNum.page - 1), threadNum.row * threadNum.page);
   var tbody = someThreads.map(function (o, i) {
     var _a, _b;
-    var threadSecondaryCategory = (_a = threadSecondaryCategorys[o["thread_secondary_category_id"] - 1]) !== null && _a !== void 0 ? _a : {};
+    var threadSecondaryCategory = (_a = threadSecondaryCategorys[o["secondaryCategoryId"] - 1]) !== null && _a !== void 0 ? _a : {};
     var threadPrimaryCategory = (_b = threadSecondaryCategory["thread_primary_category"]) !== null && _b !== void 0 ? _b : {};
     var url = dashboardUrl + "?thread_id=" + o["id"];
     return (0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("tr", {
@@ -14901,7 +14903,7 @@ var Tbody = function Tbody(_a) {
         }, {
           children: [(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("p", {
             children: (0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsxs)("small", {
-              children: [threadPrimaryCategory["name"], "：", threadSecondaryCategory["name"], " / ", "作成：", (0,_utils_format__WEBPACK_IMPORTED_MODULE_3__.formatDate)(o["created_at"])]
+              children: [threadPrimaryCategory["name"], "：", threadSecondaryCategory["name"], " / ", "作成：", (0,_utils_format__WEBPACK_IMPORTED_MODULE_3__.formatDate)(o["createdAt"])]
             })
           }), (0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("p", {
             children: o["name"]
@@ -15041,10 +15043,10 @@ var Layout = function Layout() {
       if (filter.title && !o.name.match(filter.title)) {
         response = false;
       }
-      if (filter.primaryCategory && o.thread_secondary_category.thread_primary_category_id !== filter.primaryCategory.id) {
+      if (filter.primaryCategory && o.primaryCategoryId !== filter.primaryCategory.id) {
         response = false;
       }
-      if (filter.secondaryCategory && o.thread_secondary_category_id !== filter.secondaryCategory.id) {
+      if (filter.secondaryCategory && o.secondaryCategoryId !== filter.secondaryCategory.id) {
         response = false;
       }
       return response;

--- a/resources/ts/src/features/threads/api/hubIndex.ts
+++ b/resources/ts/src/features/threads/api/hubIndex.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { axios } from "../../../lib/axios";
+import { threadEntity } from "../types";
 
 /**
  * state・スレッド一覧を取得するAPIを利用し，呼び出し元にスレッド一覧を渡す
@@ -14,8 +15,11 @@ export const hubIndex = (hubUrl: string, setThreads: CallableFunction) => {
             .then((response: any) => {
                 return response.data;
             })
-            .then((data: object) => {
-                setThreads(data);
+            .then((data: any) => {
+                return data.data;
+            })
+            .then((threads: threadEntity[]) => {
+                setThreads(threads);
             })
             .catch((error: any) => null);
     }, []);

--- a/resources/ts/src/features/threads/components/Layout.tsx
+++ b/resources/ts/src/features/threads/components/Layout.tsx
@@ -96,8 +96,7 @@ const Tbody = ({
 
     const tbody = someThreads.map((o: threadEntity, i: number) => {
         const threadSecondaryCategory: threadSecondaryCategoryEntity =
-            threadSecondaryCategorys[o["thread_secondary_category_id"] - 1] ??
-            {};
+            threadSecondaryCategorys[o["secondaryCategoryId"] - 1] ?? {};
         const threadPrimaryCategory: threadPrimaryCategoryEntity =
             threadSecondaryCategory["thread_primary_category"] ?? {};
         const url: string = dashboardUrl + "?thread_id=" + o["id"];
@@ -113,7 +112,7 @@ const Tbody = ({
                                 {threadSecondaryCategory["name"]}
                                 {" / "}
                                 {"作成："}
-                                {formatDate(o["created_at"])}
+                                {formatDate(o["createdAt"])}
                             </small>
                         </p>
                         <p>{o["name"]}</p>
@@ -279,15 +278,13 @@ export const Layout = () => {
                 }
                 if (
                     filter.primaryCategory &&
-                    o.thread_secondary_category.thread_primary_category_id !==
-                        filter.primaryCategory.id
+                    o.primaryCategoryId !== filter.primaryCategory.id
                 ) {
                     response = false;
                 }
                 if (
                     filter.secondaryCategory &&
-                    o.thread_secondary_category_id !==
-                        filter.secondaryCategory.id
+                    o.secondaryCategoryId !== filter.secondaryCategory.id
                 ) {
                     response = false;
                 }

--- a/resources/ts/src/features/threads/types/index.ts
+++ b/resources/ts/src/features/threads/types/index.ts
@@ -1,20 +1,11 @@
 /** スレッドの情報 */
 export type threadEntity = {
     id: string;
-    thread_secondary_category_id: number;
-    user_id: string;
     name: string;
-    created_at: string;
-    updated_at: string;
-    deleted_at: string;
-    thread_secondary_category: {
-        id: number;
-        thread_primary_category_id: number;
-        name: string;
-        created_at: string;
-        updated_at: string;
-    };
-    access_logs_count: number;
+    accessCount: number;
+    primaryCategoryId: number;
+    secondaryCategoryId: number;
+    createdAt: string;
 };
 
 /** 詳細カテゴリの情報 */


### PR DESCRIPTION
## 関連

- #267 

## なぜこの変更をするのか

- APIで，表示・利用する予定のない要素を取得していたから

## やったこと

- スレッド一覧取得のAPIでフロントエンドで使用しない要素を削除するためのAPIリソースクラスを作成
- 要素名なども変更したため，フロントエンドが正常に表示されるように修正

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

- スレッド一覧取得のAPIでスレッドを作成したユーザIDなどの情報を取得できないようになる

## 動作確認

- 不要な要素をAPIで取得していないことを確認
- 開発用ダッシュボードが正常に表示されることを確認

## その他

現在は使用していませんが，使用するかもしれないのでアクセス数もAPIで取得しています