### PR TITLE
書き込み取得APIのリクエスト時にバリデーションが行われるように変更

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,8 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -41,8 +43,12 @@ class Handler extends ExceptionHandler
      */
     public function register()
     {
-        $this->reportable(function (Throwable $e) {
-            //
+        $this->renderable(function (ValidationException $exception, Request $request) {
+            return response()->json([
+                'error' => 'validation_failed',
+                'message' => $exception->getMessage(),
+                'errors' => $exception->errors(),
+            ], 422);
         });
     }
 }

--- a/app/Http/Controllers/API/PostController.php
+++ b/app/Http/Controllers/API/PostController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Events\ThreadBrowsing\PostStored;
 use App\Exceptions\ThreadNotFoundException;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Post\IndexRequest;
+use App\Http\Requests\Posts\IndexRequest;
 use App\Http\Resources\PostResource;
 use App\Services\Tables\PostService;
 use App\Services\ThreadImageService;
@@ -27,7 +27,7 @@ class PostController extends Controller
     /**
      * 該当スレッドの書き込み一覧を取得する
      *
-     * @param Request $request アクセス時のパラメータなど
+     * @param IndexRequest $request アクセス時のパラメータなど
      * @return PostResource 成形済みの書き込み一覧
      */
     public function index(IndexRequest $request): PostResource

--- a/app/Http/Controllers/API/PostController.php
+++ b/app/Http/Controllers/API/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Events\ThreadBrowsing\PostStored;
 use App\Exceptions\ThreadNotFoundException;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Post\IndexRequest;
 use App\Http\Resources\PostResource;
 use App\Services\Tables\PostService;
 use App\Services\ThreadImageService;
@@ -29,7 +30,7 @@ class PostController extends Controller
      * @param Request $request アクセス時のパラメータなど
      * @return PostResource 成形済みの書き込み一覧
      */
-    public function index(Request $request): PostResource
+    public function index(IndexRequest $request): PostResource
     {
         try {
             return new PostResource($this->postService->getPostWithUserImageAndLikes(

--- a/app/Http/Requests/Post/IndexRequest.php
+++ b/app/Http/Requests/Post/IndexRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Post;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexRequest extends FormRequest
+{
+    /**
+     * ユーザーがこの要求を行う権限があるかどうかを判断する．
+     *
+     * @return boolean
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * リクエストに適用されるバリデーションルールを取得．
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'threadId' => 'required|regex:/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/'
+        ];
+    }
+}

--- a/app/Http/Requests/Posts/IndexRequest.php
+++ b/app/Http/Requests/Posts/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\Post;
+namespace App\Http\Requests\Posts;
 
 use Illuminate\Foundation\Http\FormRequest;
 


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- リクエストを検証するため

## やったこと

- 書き込み取得のAPIのリクエスト時にバリデーションが行われるように変更
- APIでバリデーションエラーが発生した際にルートへリダイレクトではなく，422エラーとおもにエラーメッセージを返却するように変更

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- バリデーションエラーが発生した際には422エラーが返却されることを確認

## その他

なし