### PR TITLE
バリデーションエラーの形式が同じになるように，Posts/StoreRequest の例外処理関数を削除

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -37,7 +37,7 @@ class Handler extends ExceptionHandler
     /**
      * アプリケーションの例外処理コールバックを登録する．
      *
-     * @link https://readouble.com/laravel/9.x/ja/errors.html
+     * @link https://readouble.com/laravel/10.x/ja/errors.html
      *
      * @return void
      */

--- a/app/Http/Requests/Posts/StoreRequest.php
+++ b/app/Http/Requests/Posts/StoreRequest.php
@@ -34,27 +34,4 @@ class StoreRequest extends FormRequest
             'img' => ['nullable', 'required_without:message', 'image', 'mimes:bmp,gif,jpg,jpeg,png,webp', 'max:3000'],
         ];
     }
-
-    /**
-     * バリデーションの失敗を処理する．
-     *
-     * @link https://laravel.com/api/9.x/Illuminate/Foundation/Http/FormRequest.html#method_failedValidation
-     * @todo 上記のリンクをメソッドの説明付きの良さげなURLに置き換える
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return void
-     *
-     * @throws \Illuminate\Http\Exceptions\HttpResponseException
-     */
-    protected function failedValidation(Validator $validator)
-    {
-        $response = response()->json(
-            [$validator->errors()],
-            422,
-            [],
-            JSON_UNESCAPED_UNICODE
-        );
-
-        throw new HttpResponseException($response);
-    }
 }


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- `app/Http/Requests/Posts/StoreRequest.php` 独自の例外処理を作成してしまっていたため
- バリデーションエラー発生時のレスポンス形式を統一するため

## やったこと

- `app/Http/Requests/Posts/StoreRequest.php` の例外処理関数を削除

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- http://localhost:8080/api/post で発生するバリデーションエラーと同じ形式のレスポンスであることを確認

## その他

なし
