### PR TITLE
スレッド作成を行うAPIの作成

### DIFF
--- a/app/Http/Controllers/API/HubController.php
+++ b/app/Http/Controllers/API/HubController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Threads\StoreRequest;
 use App\Http\Resources\ThreadResource;
 use App\Services\Tables\HubService;
 use Illuminate\Http\Request;
@@ -28,8 +29,11 @@ class HubController extends Controller
 
     /**
      * スレッドを作成する
+     *
+     * @param StoreRequest $request アクセス時のパラメータなど
+     * @return void
      */
-    public function store(Request $request)
+    public function store(StoreRequest $request)
     {
         $this->hubService->createThread(
             $request->secondaryCategoryId,

--- a/app/Http/Controllers/API/HubController.php
+++ b/app/Http/Controllers/API/HubController.php
@@ -4,16 +4,16 @@ namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ThreadResource;
-use App\Services\HubService;
+use App\Services\Tables\HubService;
 use Illuminate\Http\Request;
 
 class HubController extends Controller
 {
     private HubService $hubService;
 
-    public function __construct()
+    public function __construct(HubService $hubService)
     {
-        $this->hubService = new HubService();
+        $this->hubService = $hubService;
     }
 
     /**
@@ -21,7 +21,7 @@ class HubController extends Controller
      */
     public function index(): ThreadResource
     {
-        return new ThreadResource($this->hubService->index());
+        return new ThreadResource($this->hubService->getThreadBySCategoryAndAccessedDescendingOrder());
     }
 
     /**

--- a/app/Http/Controllers/API/HubController.php
+++ b/app/Http/Controllers/API/HubController.php
@@ -21,15 +21,21 @@ class HubController extends Controller
      */
     public function index(): ThreadResource
     {
-        return new ThreadResource($this->hubService->getThreadBySCategoryAndAccessedDescendingOrder());
+        return new ThreadResource(
+            $this->hubService->getThreadBySCategoryAndAccessedDescendingOrder()
+        );
     }
 
     /**
-     * Store a newly created resource in storage.
+     * スレッドを作成する
      */
     public function store(Request $request)
     {
-        //
+        $this->hubService->createThread(
+            $request->secondaryCategoryId,
+            $request->user()->id,
+            $request->threadName
+        );
     }
 
     /**

--- a/app/Http/Requests/Threads/StoreRequest.php
+++ b/app/Http/Requests/Threads/StoreRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Threads;
+
+use App\Consts\Tables\ThreadSecondaryCategoryConst;
+use App\Rules\MaxLineRule as max_line;
+use App\Rules\TrimRule as trim;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * ユーザーがこの要求を行う権限があるかどうかを判断する．
+     *
+     * @return boolean
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * リクエストに適用されるバリデーションルールを取得．
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        $table = ThreadSecondaryCategoryConst::NAME;
+        $column = ThreadSecondaryCategoryConst::ID;
+
+        return [
+            'secondaryCategoryId' => "required|integer|exists:{$table},{$column}",
+            'threadName' => ['required', 'string', new trim(), 'max:255', new max_line(1)],
+        ];
+    }
+}

--- a/app/Services/Tables/HubService.php
+++ b/app/Services/Tables/HubService.php
@@ -5,9 +5,18 @@ namespace App\Services\Tables;
 use App\Exceptions\ThreadNotFoundException;
 use App\Models\Hub;
 use App\Repositories\HubRepository;
+use App\Services\HubService as ServicesHubService;
+use Illuminate\Support\Collection;
 
 class HubService
 {
+    private ServicesHubService $hubService;
+
+    public function __construct(ServicesHubService $hubService)
+    {
+        $this->hubService = $hubService;
+    }
+
     /**
      * 対応するスレッドを返却する
      *
@@ -24,5 +33,21 @@ class HubService
         } else {
             throw new ThreadNotFoundException();
         }
+    }
+
+    /**
+     * スレッド一覧を取得する
+     *
+     * リレーションシップを利用して取得
+     *     thread_secondary_categorys,
+     * リレーションシップを利用してカウント
+     *     access_logs
+     * `created_at` を基準にして降順にソート
+     *
+     * @return Collection スレッド一覧
+     */
+    public function getThreadBySCategoryAndAccessedDescendingOrder(): Collection
+    {
+        return $this->hubService->index();
     }
 }

--- a/app/Services/Tables/HubService.php
+++ b/app/Services/Tables/HubService.php
@@ -50,4 +50,17 @@ class HubService
     {
         return $this->hubService->index();
     }
+
+    /**
+     * スレッドを作成する
+     *
+     * @param integer $secondaryCategoryId スレッドが属する詳細カテゴリID
+     * @param string $userId スレッドを作成したユーザID
+     * @param string $threadName スレッド名
+     * @return void
+     */
+    public function createThread(int $secondaryCategoryId, string $userId, string $threadName): void
+    {
+        HubRepository::store($secondaryCategoryId, $userId, $threadName);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,9 +14,16 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::apiResource('/hub', \App\Http\Controllers\API\HubController::class)->only(['index']);
 Route::apiResource('/threadPrimaryCategory', \App\Http\Controllers\API\ThreadPrimaryCategoryController::class)->only(['index']);
 Route::apiResource('/threadSecondaryCategory', \App\Http\Controllers\API\ThreadSecondaryCategoryController::class)->only(['index', 'show']);
+
+Route::prefix('/hub')->name('hub.')->controller(\App\Http\Controllers\API\HubController::class)->group(function () {
+    Route::get('/', 'index')->name('index');
+
+    Route::middleware(['auth:sanctum', 'verified'])->group(function () {
+        Route::post('/store', 'store')->name('store');
+    });
+});
 
 Route::prefix('/post')->name('post.')->controller(\App\Http\Controllers\API\PostController::class)->group(function () {
     Route::get('/', 'index')->name('index');


### PR DESCRIPTION
## 関連

- #170 

## やったこと

- `app/Http/Controllers/API/HubController.php` でインスタンス化していたサービスクラスを変更
- `app/Http/Controllers/API/HubController.php` にスレッド作成を行う関数を作成
- スレッド作成の関数を呼び出すルーティングを追加 http://localhost:8080/api/hub/store
- 受信したデータをバリデーションするためのリクエストクラスを作成

## やらないこと

- 現在のダッシュボードで利用しているスレッド作成用コントローラではバリデーションを行わない

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- バリデーションルールが適応されていることを確認

## その他

- 新しいダッシュボードでこのルーティングを利用する予定のため，現在のダッシュボードで利用しているスレッド作成用コントローラにはバリデーションを行いません．
- 開発用ダッシュボードに適応する予定ということで関連のイシューは閉じます．