### PR TITLE
screenコマンドを使用して，laravelのキュー・webpackのwatch をセッションで常に実行するように変更

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
-cd /usr/src/app
+screen -wipe
 
-php artisan queue:work
+screen -dmS queue
+screen -dmS build
+
+screen -S queue -X stuff ' \
+    cd "$WORKDIR"; \
+    php artisan queue:work \
+\n'
+
+screen -S build -X stuff ' \
+    cd "$WORKDIR"; \
+    npm run watch \
+\n'

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.1.4-fpm
 
 WORKDIR /usr/src/app
 
+ENV WORKDIR=/usr/src/app
 ENV LANG=C.UTF-8
 
 # Faster apt commands
@@ -11,16 +12,17 @@ RUN \
     # # Install Required Linux Packages
     apt-get update; \
     apt-get install -y --no-install-recommends \
-    git \
-    openssh-client \
-    wget \
     default-mysql-client \
+    git \
     libfreetype6-dev \
     libjpeg-dev \
     libpng-dev \
     libwebp-dev \
     libzip-dev \
+    openssh-client \
+    screen \
     unzip \
+    wget \
     zlib1g-dev \
     ; \
     DEBIAN_FRONTEND=noninteractive apt-get install postfix -y \


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- `npm run dev` などでjs, cssファイルのビルドを自動で行うため
- `php artisan queue:work` コマンドを，postStartCommand.sh を実行したターミナルを閉じても実行し続けるため

## やったこと

- `hira-chan_app` に `screen` コマンドをインストール
- `php artisan queue:work` をセッションで実行するように変更
- `npm run watch` をセッションで実行するように変更

## やらないこと

なし

## 動作確認

- postStartCommand.sh を実行したターミナルを閉じても `npm run watch` が実行し続けていることを確認

## その他

- `php artisan queue:work` を実行しているセッション名は `queue`
- `npm run watch` を実行しているセッション名は `build`
