### PR TITLE
コンテキストを利用してLaravelからReactへ渡す値を追加する

### DIFF
--- a/resources/ts/src/components/Header/Header.tsx
+++ b/resources/ts/src/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { routesContext, userContext } from "../../hooks/useContext";
 import { Logout } from "../../features/auth/components/Logout";
 import { cutText } from "../../utils/format";
+import { RoutesEntity, UserEntity } from "../../types";
 
 /**
  * HxS のロゴを表示する
@@ -23,10 +24,10 @@ const HxSLogo = () => {
  * @return {JSX.Element}
  */
 const Title = () => {
-    const routes: { [key: string]: string } = routesContext();
+    const routes: RoutesEntity = routesContext();
 
     return (
-        <a href={routes["dashboard"]} className="vw-10">
+        <a href={routes.dashboard} className="vw-10">
             <img src="/img/hira-chan.svg" alt="hira-chan logo" />
         </a>
     );
@@ -38,8 +39,8 @@ const Title = () => {
  * @return {JSX.Element}
  */
 const AcctCtrDropDown = () => {
-    const routes: { [key: string]: string } = routesContext();
-    const user: { [key: string]: string } = userContext();
+    const routes: RoutesEntity = routesContext();
+    const user: UserEntity = userContext();
 
     return (
         <div className="dropdown mx-1">
@@ -51,24 +52,24 @@ const AcctCtrDropDown = () => {
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
             >
-                {cutText(user["name"])}
+                {cutText(user.name)}
             </a>
             <ul className="dropdown-menu" aria-labelledby="dropdownMenuLink">
                 <li>
                     <p className="dropdown-header">アカウント管理</p>
                 </li>
                 <li>
-                    <a className="dropdown-item" href={routes["myPage"]}>
+                    <a className="dropdown-item" href={routes.myPage}>
                         マイページ
                     </a>
                 </li>
                 <li>
-                    <a className="dropdown-item" href={routes["threadHistory"]}>
+                    <a className="dropdown-item" href={routes.threadHistory}>
                         閲覧履歴
                     </a>
                 </li>
                 <li>
-                    <a className="dropdown-item" href={routes["profileShow"]}>
+                    <a className="dropdown-item" href={routes.profileShow}>
                         プロフィール
                     </a>
                 </li>
@@ -89,14 +90,14 @@ const AcctCtrDropDown = () => {
  * @return {JSX.Element}
  */
 const AuthFalse = () => {
-    const routes: { [key: string]: string } = routesContext();
+    const routes: RoutesEntity = routesContext();
 
     return (
         <div>
-            <a href={routes["login"]} className="btn btn-outline-dark mx-1">
+            <a href={routes.login} className="btn btn-outline-dark mx-1">
                 ログイン
             </a>
-            <a href={routes["register"]} className="btn btn-secondary mx-1">
+            <a href={routes.register} className="btn btn-secondary mx-1">
                 新規登録
             </a>
         </div>
@@ -109,7 +110,7 @@ const AuthFalse = () => {
  * @return {JSX.Element}
  */
 export const Header = () => {
-    const user: { [key: string]: string } = userContext();
+    const user: UserEntity = userContext();
     const acctCtr = user["name"] !== "" ? AcctCtrDropDown() : AuthFalse();
 
     return (

--- a/resources/ts/src/features/auth/components/Logout.tsx
+++ b/resources/ts/src/features/auth/components/Logout.tsx
@@ -1,4 +1,5 @@
 import { routesContext } from "../../../hooks/useContext";
+import { RoutesEntity } from "../../../types";
 import { logout } from "../api/logout";
 
 /** ログアウト用のリンクを表示する関数の引数の型 */
@@ -13,7 +14,7 @@ type logoutProps = {
  * @returns
  */
 export const Logout = (props: logoutProps) => {
-    const routes: { [key: string]: string } = routesContext();
+    const routes: RoutesEntity = routesContext();
 
     return (
         <a

--- a/resources/ts/src/features/threads/api/hubIndex.ts
+++ b/resources/ts/src/features/threads/api/hubIndex.ts
@@ -1,17 +1,19 @@
 import { useEffect } from "react";
 import { axios } from "../../../lib/axios";
 import { threadEntity } from "../types";
+import { routesContext } from "../../../hooks/useContext";
 
 /**
  * state・スレッド一覧を取得するAPIを利用し，呼び出し元にスレッド一覧を渡す
  *
- * @param {string} hubUrl - スレッド一覧を取得するAPIのURL
  * @param {CallableFunction} setThreads - stateでスレッド一覧を保存するための関数
  */
-export const hubIndex = (hubUrl: string, setThreads: CallableFunction) => {
+export const hubIndex = (setThreads: CallableFunction) => {
+    const routes = routesContext();
+
     useEffect(() => {
         axios
-            .get(hubUrl)
+            .get(routes.hub.index)
             .then((response: any) => {
                 return response.data;
             })

--- a/resources/ts/src/features/threads/api/threadPrimaryCategoryIndex.ts
+++ b/resources/ts/src/features/threads/api/threadPrimaryCategoryIndex.ts
@@ -1,19 +1,20 @@
 import { useEffect } from "react";
 import { axios } from "../../../lib/axios";
+import { routesContext } from "../../../hooks/useContext";
 
 /**
  * state・大枠カテゴリ一覧を取得するAPIを利用し，呼び出し元に大枠カテゴリ一覧を渡す
  *
- * @param {string} threadPrimaryCategoryUrl - 大枠カテゴリ一覧を取得するAPIのURL
  * @param {CallableFunction} setThreadPrimaryCategorys - stateで大枠カテゴリ一覧を保存するための関数
  */
 export const threadPrimaryCategoryIndex = (
-    threadPrimaryCategoryUrl: string,
     setThreadPrimaryCategorys: CallableFunction
 ) => {
+    const routes = routesContext();
+
     useEffect(() => {
         axios
-            .get(threadPrimaryCategoryUrl)
+            .get(routes.threadPrimaryCategory.index)
             .then((response: any) => {
                 return response.data;
             })

--- a/resources/ts/src/features/threads/api/threadSecondaryCategoryIndex.ts
+++ b/resources/ts/src/features/threads/api/threadSecondaryCategoryIndex.ts
@@ -1,19 +1,20 @@
 import { useEffect } from "react";
 import { axios } from "../../../lib/axios";
+import { routesContext } from "../../../hooks/useContext";
 
 /**
  * state・詳細カテゴリ一覧を取得するAPIを利用し，呼び出し元に詳細カテゴリ一覧を渡す
  *
- * @param {string} threadSecondaryCategoryUrl - 詳細カテゴリ一覧を取得するAPIのURL
  * @param {CallableFunction} setThreadSecondaryCategorys - stateで詳細カテゴリ一覧を保存するための関数
  */
 export const threadSecondaryCategoryIndex = (
-    threadSecondaryCategoryUrl: string,
     setThreadSecondaryCategorys: CallableFunction
 ) => {
+    const routes = routesContext();
+
     useEffect(() => {
         axios
-            .get(threadSecondaryCategoryUrl)
+            .get(routes.threadSecondaryCategory.index)
             .then((response: any) => {
                 return response.data;
             })

--- a/resources/ts/src/features/threads/components/Layout.tsx
+++ b/resources/ts/src/features/threads/components/Layout.tsx
@@ -227,7 +227,7 @@ export type threadNumType = {
  * @returns {JSX.Element}
  */
 export const Layout = () => {
-    const routes: { [key: string]: string } = routesContext();
+    const routes = routesContext();
     const [filter, setFilter] = useState<filterType>({});
     const [threadNum, setThreadNum] = useState<threadNumType>({
         row: 10,
@@ -247,15 +247,9 @@ export const Layout = () => {
     const [searchThreadModalIsOpen, setSearchThreadModalIsOpen] =
         useState<boolean>(false);
 
-    hubIndex(routes["hub"], setThreads);
-    threadPrimaryCategoryIndex(
-        routes["threadPrimaryCategory"],
-        setThreadPrimaryCategorys
-    );
-    threadSecondaryCategoryIndex(
-        routes["threadSecondaryCategory"],
-        setThreadSecondaryCategorys
-    );
+    hubIndex(setThreads);
+    threadPrimaryCategoryIndex(setThreadPrimaryCategorys);
+    threadSecondaryCategoryIndex(setThreadSecondaryCategorys);
     useEffect(() => setProcessedThreads(threads), [threads]);
     useEffect(() => {
         setThreadNum((state: threadNumType) => ({
@@ -341,7 +335,7 @@ export const Layout = () => {
                     threads={processedThreads}
                     threadSecondaryCategorys={threadSecondaryCategorys}
                     threadNum={threadNum}
-                    dashboardUrl={routes["dashboard"]}
+                    dashboardUrl={routes.dashboard}
                 />
             </table>
             <SelectPage threadNum={threadNum} onClick={handleSelectPageClick} />

--- a/resources/ts/src/hooks/useContext.ts
+++ b/resources/ts/src/hooks/useContext.ts
@@ -1,18 +1,17 @@
 import { useContext } from "react";
 import { RoutesContext, UserContext } from "../providers/app";
+import { RoutesEntity, UserEntity } from "../types";
 
 /**
  * アプリで共通して使用可能なルートを返却する
  *
- * @return {{ [key: string]: string  }}
+ * @return { RoutesEntity }
  */
-export const routesContext = (): { [key: string]: string } =>
-    useContext(RoutesContext);
+export const routesContext = () => useContext(RoutesContext) as RoutesEntity;
 
 /**
  * ログインしていれば，ログインしているユーザの情報を返却する
  *
- * @return {{ [key: string]: string }}
+ * @return { UserEntity }
  */
-export const userContext = (): { [key: string]: string } =>
-    useContext(UserContext);
+export const userContext = () => useContext(UserContext) as UserEntity;

--- a/resources/ts/src/hooks/useContext.ts
+++ b/resources/ts/src/hooks/useContext.ts
@@ -1,6 +1,11 @@
 import { useContext } from "react";
-import { RoutesContext, UserContext } from "../providers/app";
-import { RoutesEntity, UserEntity } from "../types";
+import {
+    ChannelContext,
+    EventContext,
+    RoutesContext,
+    UserContext,
+} from "../providers/app";
+import { ChannelEntity, EventEntity, RoutesEntity, UserEntity } from "../types";
 
 /**
  * アプリで共通して使用可能なルートを返却する
@@ -15,3 +20,18 @@ export const routesContext = () => useContext(RoutesContext) as RoutesEntity;
  * @return { UserEntity }
  */
 export const userContext = () => useContext(UserContext) as UserEntity;
+
+/**
+ * /** Laravel からブロードキャストされるイベント名を返却する
+ *
+ * @returns { EventEntity }
+ */
+export const eventsContext = () => useContext(EventContext) as EventEntity;
+
+/**
+ * /** Laravel からイベントを受け取るために接続するチャンネル名を返却する
+ *
+ * @returns { ChannelEntity }
+ */
+export const channelsContext = () =>
+    useContext(ChannelContext) as ChannelEntity;

--- a/resources/ts/src/providers/app.tsx
+++ b/resources/ts/src/providers/app.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { RoutesType, UserType } from "../types/index";
+import { RoutesEntity, UserEntity } from "../types/index";
 
 /** アプリ全体のプロバイダに渡す引数の型 */
 type AppProviderProps = {
@@ -23,7 +23,7 @@ export const AppProvider: CallableFunction = ({
 }: AppProviderProps) => {
     const element = document.getElementById("main");
 
-    const routes: RoutesType = {
+    const routes: RoutesEntity = {
         dashboard: element?.dataset.dashboardurl ?? "",
         myPage: element?.dataset.mypageurl ?? "",
         threadHistory: element?.dataset.threadhistoryurl ?? "",
@@ -42,7 +42,7 @@ export const AppProvider: CallableFunction = ({
         },
     };
 
-    const user: UserType = {
+    const user: UserEntity = {
         name: element?.dataset.username ?? "",
     };
 

--- a/resources/ts/src/providers/app.tsx
+++ b/resources/ts/src/providers/app.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { RoutesEntity, UserEntity } from "../types/index";
+import {
+    ChannelEntity,
+    EventEntity,
+    RoutesEntity,
+    UserEntity,
+} from "../types/index";
 
 /** アプリ全体のプロバイダに渡す引数の型 */
 type AppProviderProps = {
@@ -11,6 +16,12 @@ export const RoutesContext: React.Context<{}> = React.createContext({});
 
 /** ログインしているユーザの情報を保存したコンテキスト */
 export const UserContext: React.Context<{}> = React.createContext({});
+
+/** Laravel からブロードキャストされるイベント名を保存したコンテキスト */
+export const EventContext: React.Context<{}> = React.createContext({});
+
+/** Laravel からイベントを受け取るために接続するチャンネル名を保存したコンテキスト */
+export const ChannelContext: React.Context<{}> = React.createContext({});
 
 /**
  * アプリ共通で使用可能な値を設定する
@@ -33,6 +44,7 @@ export const AppProvider: CallableFunction = ({
         register: element?.dataset.registerurl ?? "",
         hub: {
             index: element?.dataset.hubindexurl ?? "",
+            store: element?.dataset.hubstoreurl ?? "",
         },
         threadPrimaryCategory: {
             index: element?.dataset.threadprimarycategoryindexurl ?? "",
@@ -40,15 +52,43 @@ export const AppProvider: CallableFunction = ({
         threadSecondaryCategory: {
             index: element?.dataset.threadsecondarycategoryindexurl ?? "",
         },
+        like: {
+            store: element?.dataset.likestoreurl ?? "",
+            destroy: element?.dataset.likedestroyurl ?? "",
+        },
+        post: {
+            index: element?.dataset.postindexurl ?? "",
+            store: element?.dataset.poststoreurl ?? "",
+        },
     };
 
     const user: UserEntity = {
         name: element?.dataset.username ?? "",
     };
 
+    const events: EventEntity = {
+        threadBrowsing: {
+            addLikeOnPost:
+                element?.dataset.threadbrowsingaddlikeonpostevent ?? "",
+            deleteLikeOnPost:
+                element?.dataset.threadbrowsingdeletelikeonpostevent ?? "",
+            postStored: element?.dataset.threadbrowsingpoststoredevent ?? "",
+        },
+    };
+
+    const channels: ChannelEntity = {
+        threadBrowsing: element?.dataset.threadbrowsingchannel ?? "",
+    };
+
     return (
         <RoutesContext.Provider value={routes}>
-            <UserContext.Provider value={user}>{children}</UserContext.Provider>
+            <UserContext.Provider value={user}>
+                <EventContext.Provider value={events}>
+                    <ChannelContext.Provider value={channels}>
+                        {children}
+                    </ChannelContext.Provider>
+                </EventContext.Provider>
+            </UserContext.Provider>
         </RoutesContext.Provider>
     );
 };

--- a/resources/ts/src/providers/app.tsx
+++ b/resources/ts/src/providers/app.tsx
@@ -31,10 +31,15 @@ export const AppProvider: CallableFunction = ({
         login: element?.dataset.loginurl ?? "",
         logout: element?.dataset.logouturl ?? "",
         register: element?.dataset.registerurl ?? "",
-        hub: element?.dataset.huburl ?? "",
-        threadPrimaryCategory: element?.dataset.threadprimarycategoryurl ?? "",
-        threadSecondaryCategory:
-            element?.dataset.threadsecondarycategoryurl ?? "",
+        hub: {
+            index: element?.dataset.hubindexurl ?? "",
+        },
+        threadPrimaryCategory: {
+            index: element?.dataset.threadprimarycategoryindexurl ?? "",
+        },
+        threadSecondaryCategory: {
+            index: element?.dataset.threadsecondarycategoryindexurl ?? "",
+        },
     };
 
     const user: UserType = {

--- a/resources/ts/src/types/index.ts
+++ b/resources/ts/src/types/index.ts
@@ -9,6 +9,7 @@ export type RoutesEntity = {
     register: string;
     hub: {
         index: string;
+        store: string;
     };
     threadPrimaryCategory: {
         index: string;
@@ -16,9 +17,31 @@ export type RoutesEntity = {
     threadSecondaryCategory: {
         index: string;
     };
+    like: {
+        store: string;
+        destroy: string;
+    };
+    post: {
+        index: string;
+        store: string;
+    };
 };
 
 /** ログインしてるユーザ情報の型 */
 export type UserEntity = {
     name: string;
+};
+
+/** Laravel からブロードキャストされるイベント名 */
+export type EventEntity = {
+    threadBrowsing: {
+        addLikeOnPost: string;
+        deleteLikeOnPost: string;
+        postStored: string;
+    };
+};
+
+/** Laravel からイベントを受け取るために接続するチャンネル名 */
+export type ChannelEntity = {
+    threadBrowsing: string;
 };

--- a/resources/ts/src/types/index.ts
+++ b/resources/ts/src/types/index.ts
@@ -7,9 +7,15 @@ export type RoutesType = {
     login: string;
     logout: string;
     register: string;
-    hub: string;
-    threadPrimaryCategory: string;
-    threadSecondaryCategory: string;
+    hub: {
+        index: string;
+    };
+    threadPrimaryCategory: {
+        index: string;
+    };
+    threadSecondaryCategory: {
+        index: string;
+    };
 };
 
 /** ログインしてるユーザ情報の型 */

--- a/resources/ts/src/types/index.ts
+++ b/resources/ts/src/types/index.ts
@@ -1,5 +1,5 @@
 /** アプリ共通で使用可能なルートの型 */
-export type RoutesType = {
+export type RoutesEntity = {
     dashboard: string;
     myPage: string;
     threadHistory: string;
@@ -19,6 +19,6 @@ export type RoutesType = {
 };
 
 /** ログインしてるユーザ情報の型 */
-export type UserType = {
+export type UserEntity = {
     name: string;
 };

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -41,10 +41,30 @@
         data-mypageurl={{ route('mypage') }}
         data-threadhistoryurl={{ route('thread.history') }}
         data-profileshowurl={{ route('profile.show') }}
+
         data-hubindexurl={{ route('hub.index') }}
+        data-hubstoreurl={{ route('hub.index') . '/store' }}
+
         data-threadprimarycategoryindexurl={{ route('threadPrimaryCategory.index') }}
         data-threadsecondarycategoryindexurl={{ route('threadSecondaryCategory.index') }}
 
+        data-likestoreurl={{ route('like.index') . '/store' }}
+        data-likedestroyurl={{ route('like.index') . '/destroy' }}
+
+        data-postindexurl={{ route('post.index') }}
+        data-poststoreurl={{ route('post.index') . '/store' }}
+
+
+        {{-- イベント --}}
+        data-threadbrowsingaddlikeonpostevent={{ 'ThreadBrowsing\\AddLikeOnPost' }}
+        data-threadbrowsingdeletelikeonpostevent={{ 'ThreadBrowsing\\DeleteLikeOnPost' }}
+        data-threadbrowsingpoststoredevent={{ 'ThreadBrowsing\\PostStored' }}
+
+
+        {{-- チャンネル --}}
+        data-threadbrowsingchannel={{ \App\Consts\ChannelConst::THREAD_BROWSING }}
+
+        
         {{-- ユーザ名 --}}
         data-username={{ Auth::check() && Auth::user()->hasVerifiedEmail() ? Auth::user()->name : null }}
     >

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -30,15 +30,24 @@
 </head>
 
 <body class="antialiased">
-    <main id="main" data-dashboardurl={{ {{-- route('dashboard') --}} route('dashboard.dev') }} data-loginurl={{
-        route('login') }} data-logouturl={{route('logout') }} data-registerurl={{ route('register') }} data-mypageurl={{
-        route('mypage') }} data-threadhistoryurl={{ route('thread.history') }} data-profileshowurl={{
-        route('profile.show') }} data-huburl={{ route('hub.index') }} data-threadprimarycategoryurl={{
-        route('threadPrimaryCategory.index') }} data-threadsecondarycategoryurl={{
-        route('threadSecondaryCategory.index') }} data-username={{ Auth::check() && Auth::user()->
-        hasVerifiedEmail()
-        ? Auth::user()->name : null }}
-        >
+    <main
+        id="main"
+
+        {{-- ルーティング --}}
+        data-dashboardurl={{ {{-- route('dashboard') --}} route('dashboard.dev') }}
+        data-loginurl={{ route('login') }}
+        data-logouturl={{route('logout') }}
+        data-registerurl={{ route('register') }}
+        data-mypageurl={{ route('mypage') }}
+        data-threadhistoryurl={{ route('thread.history') }}
+        data-profileshowurl={{ route('profile.show') }}
+        data-hubindexurl={{ route('hub.index') }}
+        data-threadprimarycategoryindexurl={{ route('threadPrimaryCategory.index') }}
+        data-threadsecondarycategoryindexurl={{ route('threadSecondaryCategory.index') }}
+
+        {{-- ユーザ名 --}}
+        data-username={{ Auth::check() && Auth::user()->hasVerifiedEmail() ? Auth::user()->name : null }}
+    >
         @yield("main")
     </main>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,6 +34,8 @@ Route::prefix('/post')->name('post.')->controller(\App\Http\Controllers\API\Post
 });
 
 Route::prefix('/like')->name('like.')->controller(\App\Http\Controllers\API\LikeController::class)->group(function () {
+    Route::get('/', fn () => abort(404))->name('index');
+
     Route::middleware(['auth:sanctum', 'verified'])->group(function () {
         Route::post('/store', 'store')->name('store');
         Route::post('/destroy', 'destroy')->name('destroy');


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- 追加されたAPIがあるから
- 追加されたイベントがあるから
- 追加されたチャンネルがあるから

## やったこと

- Reactでコンテキストで取得する値がわかりやすいように変更
- APIをたたくメソッドでコンテキストからルーティングを取得するように変更（src/features/threads/api/*）
- コンテキストで取得する値の型名を変更
- 新たに作成したAPIルーティング・Event名・Channel名をコンテキストに追加

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- コンテキストから追加した値を取得可能なことを確認しました

## その他

なし