### PR TITLE
fix: 適切なフィールド名に変更し，バリデーションルールが適応されるように変更

### DIFF
--- a/app/Http/Requests/Posts/StoreRequest.php
+++ b/app/Http/Requests/Posts/StoreRequest.php
@@ -28,7 +28,7 @@ class StoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'thread_id' => 'required|regex:/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            'threadId' => 'required|regex:/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
             'reply' => 'integer|nullable',
             'message' => ['nullable', 'required_without:img', 'string', new trim(), 'max:800', new max_line(20)],
             'img' => ['nullable', 'required_without:message', 'image', 'mimes:bmp,gif,jpg,jpeg,png,webp', 'max:3000'],


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- バリデーションのフィールド名が誤っており，バリデーションルールが適切に適応されていなかったから

## やったこと

- Posts/StoreRequest のバリデーションルールのフィールド名を `thread_id` -> `threadId` に変更

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- `threadId` フィールドのバリデーションルールが適応されていることを確認
- このAPIを利用して書き込みが可能なことを確認

## その他

なし