### PR TITLE
apiのルーティング時のみjson形式でのバリデーションエラーを返却する

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,11 +44,13 @@ class Handler extends ExceptionHandler
     public function register()
     {
         $this->renderable(function (ValidationException $exception, Request $request) {
-            return response()->json([
-                'error' => 'validation_failed',
-                'message' => $exception->getMessage(),
-                'errors' => $exception->errors(),
-            ], 422);
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'error' => 'validation_failed',
+                    'message' => $exception->getMessage(),
+                    'errors' => $exception->errors(),
+                ], 422);
+            }
         });
     }
 }


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- ログイン・新規登録画面でバリデーションエラーが発生した際にも json 形式でエラーが返却されていたため

## やったこと

- ルーティングが `api/*` の場合のみ json 形式でバリデーションエラーを返却する様に変更

## やらないこと

なし

## できるようになること（ユーザ目線）

- ログイン画面・新規登録画面でのバリデーションメッセージが正しく表示されるようになる

## できなくなること（ユーザ目線）

なし

## 動作確認

- 新規登録画面でのバリデーションが画面にエラーメッセージとして表示されることを確認
- ログイン画面でのバリデーションが画面にエラーメッセージとして表示されることを確認

## その他

なし