### PR TITLE
既存ダッシュボードにおけるスレッドへの書き込み時バリデーションルールを修正

### DIFF
--- a/app/Http/Controllers/Dashboard/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/ThreadsController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Dashboard;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Posts\StoreRequest;
 use App\Services\PostService;
 use App\Services\ThreadImageService;
 use Illuminate\Http\Request;
@@ -46,7 +45,7 @@ class ThreadsController extends Controller
      * @param  StoreRequest  $request
      * @return void
      */
-    public function store(StoreRequest $request)
+    public function store(Request $request)
     {
         $message = is_null($request->message) && $request->img instanceof UploadedFile
             ? ''


### PR DESCRIPTION
## 関連

- なし

## なぜこの変更をするのか

- 新規のダッシュボード用に作成したバリデーションルールを既存のダッシュボードの方にも適応してしまっていたため

## やったこと

- 既存ダッシュボードに適応されていた不要なバリデーションルールを削除

## やらないこと

- なし

## できるようになること（ユーザ目線）

- 既存ダッシュボードでスレッドに正しく書き込みを行うことができる様になる

## できなくなること（ユーザ目線）

なし

## 動作確認

- 既存のダッシュボードに不要なバリデーションルールが適応されていない事を確認しました

## その他

なし