### PR TITLE
メール送信が正常に行えるよう修正

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -8,34 +8,37 @@ cat <<EOF >> ~/.bashrc
 source $HOME/.git-completion.bash
 EOF
 
-# .envファイルをプロジェクトルートに配置する
-cp /usr/src/app/.env.example /usr/src/app/.env
+# .envファイルが存在しない場合
+if [ ! -e "/usr/src/app/.env" ]; then
+    # .envファイルをプロジェクトルートに配置する
+    cp /usr/src/app/.env.example /usr/src/app/.env
+
+    # hira-chanを動作させるために .env ファイルを修正する
+    sed -ie "s/DB_HOST=127.0.0.1/DB_HOST=hira-chan_mariadb/g" /usr/src/app/.env
+    sed -ie "s/DB_DATABASE=/DB_DATABASE=forum/g" /usr/src/app/.env
+    sed -ie "s/DB_PASSWORD=/DB_PASSWORD=rootpass/g" /usr/src/app/.env
+    sed -ie "s/MAIL_FROM_ADDRESS=null/MAIL_FROM_ADDRESS=hira-chan@example.com/g" /usr/src/app/.env
+    sed -ie "s/REDIS_HOST=127.0.0.1/REDIS_HOST=hira-chan_redis/g" /usr/src/app/.env
+
+    # 環境ファイルコピー時に作成される不要ファイルの削除
+    rm /usr/src/app/.enve
+fi
 
 # スレッドにアップロードされた画像を格納するディレクトリの作成
 mkdir -p storage/app/public/images/thread_message
 
 # ディレクトリのパーミッションを変更し、laravelが書き込みできるようにする。
-chmod -R 777 storage
-chmod -R 777 bootstrap/cache
+sudo chmod -R 777 storage
+sudo chmod -R 777 bootstrap/cache
 
 # 開発で使用するPHPやNodeのパッケージのインストール
 composer install
 npm install
-
-# hira-chanを動作させるために .env ファイルを修正する
-sed -ie "s/DB_HOST=127.0.0.1/DB_HOST=hira-chan_mariadb/g" /usr/src/app/.env
-sed -ie "s/DB_DATABASE=/DB_DATABASE=forum/g" /usr/src/app/.env
-sed -ie "s/DB_PASSWORD=/DB_PASSWORD=rootpass/g" /usr/src/app/.env
-sed -ie "s/MAIL_FROM_ADDRESS=null/MAIL_FROM_ADDRESS=hira-chan@example.com/g" /usr/src/app/.env
-sed -ie "s/REDIS_HOST=127.0.0.1/REDIS_HOST=hira-chan_redis/g" /usr/src/app/.env
 
 # hira-chanを動作させるためのコマンドの実行
 php artisan key:generate
 php artisan migrate
 php artisan db:seed
 php artisan storage:link
-
-# 環境ファイルコピー時に作成される不要ファイルの削除
-rm /usr/src/app/.enve
 
 exit 0

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -17,6 +17,7 @@ RUN \
         libfreetype6-dev \
         libjpeg-dev \
         libpng-dev \
+        libsasl2-modules \
         libwebp-dev \
         libzip-dev \
         openssh-client \

--- a/docker/app/postfix/main.cf
+++ b/docker/app/postfix/main.cf
@@ -17,11 +17,12 @@ append_dot_mydomain = no
 
 readme_directory = no
 
-# See http://www.postfix.org/COMPATIBILITY_README.html -- default to 2 on
+# See http://www.postfix.org/COMPATIBILITY_README.html -- default to 3.6 on
 # fresh installs.
-compatibility_level = 2
+compatibility_level = 3.6
 
-
+# mail log
+maillog_file = /var/log/mail.log
 
 # TLS parameters
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
@@ -34,7 +35,7 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
-myhostname = ubu-srv.flets-west.jp
+myhostname = localhost
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydestination = $myhostname, ubu-srv, localhost.localdomain, , localhost
@@ -42,7 +43,7 @@ relayhost = [smtp.gmail.com]:587
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
-inet_interfaces = all
+inet_interfaces = localhost
 inet_protocols = ipv4
 
 smtp_use_tls = yes

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   hira-chan_app:
-    image: hira-chan:app-1.0.0
+    image: hira-chan:app-1.0.1
     container_name: hira-chan_app
     build:
       context: ..
@@ -11,11 +11,6 @@ services:
       TZ: Asia/Tokyo
     volumes:
       - ..:/usr/src/app
-      - ./app/nginx/default:/etc/nginx/sites-available/default
-      - ./app/php/php.ini:/etc/php/8.1/fpm/pool.d/www.ini
-      - ./app/php/php.ini:/etc/php/8.1/fpm/php.ini
-      - ./app/php/php.ini:/etc/php/8.1/cli/php.ini
-      - ./app/postfix/main.cf:/etc/postfix/main.cf
     ports:
       - 80:80
     depends_on:


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- メール送信が行えなかったため

## やったこと

- `.env`ファイルが存在する場合にはファイルを生成しないように変更
- `libsasl2-modules` ライブラリをインストールし，gmailの認証が正常に行える様に修正
- postfix - main.cf `compatibility_level ` の値を 3.6 に変更
- postfix - main.cf ホスト名を `localhost` に変更
- postfix - main.cf 送受信設定の受信を `localhost` からのものに限定
- image `hira-chan_app` のvolumesで不要な項目を削除

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- `.env` ファイルがすでにある場合には `.env` ファイルが新たに生成されないことを確認
- `.env` ファイルの `MAIL_USERNAME`，`MAIL_PASSWORD` を設定，メールが送信されることを確認

## その他

なし