### PR TITLE
開発環境にnginxコンテナを導入・php artisan serve コマンドでの開発鯖を起動しない

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,19 @@
 version: "3.8"
 services:
+  hira-chan_nginx:
+    image: hira-chan:nginx-1.0.0
+    container_name: hira-chan_nginx
+    build:
+      context: .
+      dockerfile: ./docker/nginx/Dockerfile
+    ports:
+      - 80:80
+    depends_on:
+      - hira-chan_app
+    tty: true
+
   hira-chan_app:
-    image: hira-chan:app-2.0.0
+    image: hira-chan:app-2.1.0
     container_name: hira-chan_app
     build:
       context: .
@@ -10,7 +22,6 @@ services:
     volumes:
       - .:/usr/src/app
     ports:
-      - 80:80
       - 5173:5173
     depends_on:
       - hira-chan_echo-server

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -26,6 +26,7 @@ RUN \
         unzip \
         wget \
         zlib1g-dev \
+        php-fpm \
         php-ctype \
         php-curl \
         php-dom \
@@ -65,6 +66,7 @@ COPY --from=composer:2.5.5 /usr/bin/composer /usr/bin/composer
 
 # 設定ファイルをコピー
 COPY ./docker/app/php/php.ini /etc/php/8.1/cli/php.ini
+COPY ./docker/app/php/www.conf /etc/php/8.1/fpm/pool.d/www.conf
 COPY ./docker/app/postfix/main.cf /etc/postfix/main.cf
 
 # コンテナ作成時に実行するスクリプトをコピー

--- a/docker/app/bin/containerStart.sh
+++ b/docker/app/bin/containerStart.sh
@@ -25,6 +25,7 @@ fi
 # 各種サービス起動
 sudo su <<EOF
 service postfix start
+service php8.1-fpm start
 EOF
 
 # 使用できないセッションの削除
@@ -33,7 +34,6 @@ screen -wipe
 # セッションの作成
 screen -dmS vite
 screen -dmS queue
-screen -dmS serve
 
 # vite セッションで vite を用いた自動ビルドを動作
 screen -S vite -X stuff ' \
@@ -45,12 +45,6 @@ screen -S vite -X stuff ' \
 screen -S queue -X stuff ' \
     cd "$WORKDIR"; \
     php artisan queue:work \
-\n'
-
-# serve セッションで Laravel のサーバーを動作
-screen -S serve -X stuff ' \
-    cd "$WORKDIR"; \
-    php artisan serve --host 0.0.0.0 --port 80 \
 \n'
 
 sleep infinity

--- a/docker/app/php/www.conf
+++ b/docker/app/php/www.conf
@@ -1,0 +1,15 @@
+[www]
+user = www-data
+group = www-data
+
+listen = hira-chan_app:9000
+listen.owner = www-data
+listen.group = www-data
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+
+request_terminate_timeout = 3600

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.24.0
+
+ENV TZ="Asia/Tokyo"
+ENV LANG="ja_JP.UTF-8"
+
+COPY ./docker/nginx/conf.d /etc/nginx/conf.d

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,0 +1,39 @@
+server {
+    listen 80;
+    listen [::]:80;
+    root /usr/src/app;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+
+    index index.php index.html;
+
+    charset utf-8;
+
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
+    error_page 404 /index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        root /usr/src/app/public;
+        fastcgi_pass hira-chan_app:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}


### PR DESCRIPTION
## 関連

- #291 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [ ] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [x] その他

## 変更の詳細

**`compose.yml`**

- `hira-chan_nginx` サービスを追加
- `hira-chan_app` サービスで使用しなくなったポートを削除

**`docker/app/Dockerfile`**

- `php-fpm` のインストール
- 設定ファイルの追加

**`docker/app/bin/containerStart.sh`**

- `php-fpm` の起動コマンドを追加
- `php artisan serve` コマンドで開発鯖を起動しないように

**`docker/app/php/www.conf`**

- `php-fpm` の設定ファイル作成

**`docker/nginx/Dockerfile`**

- `hira-chan_nginx` サービスの Dockerfile 作成

**`docker/nginx/conf.d/default.conf`**

- `hira-chan_nginx` サービスから fastcgi を利用して `hira-chan_app` の Laravel にアクセスできるように設定

## 動作確認

- 関連するコンテナ・イメージを削除後に `docker compose up -d` で起動した際に、正常にアクセスできることを確認

## その他

なし
